### PR TITLE
Mino: fix sync of responses and errors with Call

### DIFF
--- a/blockchain/skipchain/ops_test.go
+++ b/blockchain/skipchain/ops_test.go
@@ -56,7 +56,7 @@ func TestOperations_CatchUp(t *testing.T) {
 	require.EqualError(t, err, "couldn't read last block: oops")
 
 	ops.db = &fakeDatabase{blocks: []types.SkipBlock{{}}}
-	ops.rpc = fake.NewBadStreamRPC()
+	ops.rpc = fake.NewBadRPC()
 	err = ops.catchUp(5, nil)
 	require.EqualError(t, err, "couldn't open stream: fake error")
 

--- a/consensus/qsc/mod.go
+++ b/consensus/qsc/mod.go
@@ -51,12 +51,6 @@ func NewQSC(node int64, mino mino.Mino, players mino.Players) (*Consensus, error
 	}, nil
 }
 
-// GetChain implements consensus.Consensus. It returns the chain that can prove
-// the integrity of the proposal with the given identifier.
-func (c *Consensus) GetChain(id []byte) (consensus.Chain, error) {
-	return nil, nil
-}
-
 // Listen implements consensus.Consensus. It returns the actor that provides the
 // primitives to send proposals to a network of nodes.
 func (c *Consensus) Listen(r consensus.Reactor) (consensus.Actor, error) {

--- a/cosi/flatcosi/handler_test.go
+++ b/cosi/flatcosi/handler_test.go
@@ -9,6 +9,7 @@ import (
 	"go.dedis.ch/dela/internal/testing/fake"
 	"go.dedis.ch/dela/mino"
 	"go.dedis.ch/dela/serde"
+	"golang.org/x/xerrors"
 )
 
 func TestHandler_Process(t *testing.T) {
@@ -24,6 +25,11 @@ func TestHandler_Process(t *testing.T) {
 	require.EqualError(t, err, "invalid message type 'fake.Message'")
 	require.Nil(t, resp)
 
+	h.reactor = fakeReactor{err: xerrors.New("oops")}
+	_, err = h.Process(req)
+	require.EqualError(t, err, "couldn't hash message: oops")
+
+	h.reactor = fakeReactor{}
 	h.signer = fake.NewBadSigner()
 	_, err = h.Process(req)
 	require.EqualError(t, err, "couldn't sign: fake error")

--- a/cosi/threshold/actor_test.go
+++ b/cosi/threshold/actor_test.go
@@ -64,7 +64,7 @@ func TestActor_Sign(t *testing.T) {
 	err = actor.merge(&Signature{}, resp, 0, fake.NewInvalidPublicKey(), []byte{})
 	require.EqualError(t, err, "couldn't verify: fake error")
 
-	actor.rpc = fake.NewBadStreamRPC()
+	actor.rpc = fake.NewBadRPC()
 	_, err = actor.Sign(ctx, fake.Message{}, ca)
 	require.EqualError(t, err, "couldn't open stream: fake error")
 }

--- a/dkg/pedersen/mod_test.go
+++ b/dkg/pedersen/mod_test.go
@@ -30,7 +30,7 @@ func TestPedersen_Listen(t *testing.T) {
 
 func TestPedersen_Setup(t *testing.T) {
 	actor := Actor{
-		rpc:      fake.NewBadStreamRPC(),
+		rpc:      fake.NewBadRPC(),
 		startRes: &state{},
 	}
 
@@ -87,7 +87,7 @@ func TestPedersen_GetPublicKey(t *testing.T) {
 
 func TestPedersen_Decrypt(t *testing.T) {
 	actor := Actor{
-		rpc:      fake.NewBadStreamRPC(),
+		rpc:      fake.NewBadRPC(),
 		startRes: &state{participants: []mino.Address{fake.NewAddress(0)}, distrKey: suite.Point()},
 	}
 

--- a/mino/gossip/flat_test.go
+++ b/mino/gossip/flat_test.go
@@ -44,14 +44,15 @@ func TestActor_Add(t *testing.T) {
 		players: fake.NewAuthority(3, fake.NewSigner),
 	}
 
-	close(rpc.Msgs)
-
+	rpc.Done()
 	err := actor.Add(fakeRumor{})
 	require.NoError(t, err)
 
 	rpc = fake.NewRPC()
 	actor.rpc = rpc
-	rpc.Errs <- xerrors.New("oops")
+	rpc.SendResponseWithError(nil, xerrors.New("oops"))
+	rpc.Done()
+
 	err = actor.Add(fakeRumor{})
 	require.EqualError(t, err, "couldn't send the rumor: oops")
 

--- a/mino/minoch/rpc.go
+++ b/mino/minoch/rpc.go
@@ -52,7 +52,7 @@ func (c RPC) Call(ctx context.Context,
 	for iter.HasNext() {
 		peer, err := c.manager.get(iter.GetNext())
 		if err != nil {
-			// Abort everything is a peer is missing.
+			// Abort everything if a peer is missing.
 			return nil, xerrors.Errorf("couldn't find peer: %v", err)
 		}
 

--- a/mino/minogrpc/rpc_test.go
+++ b/mino/minogrpc/rpc_test.go
@@ -26,13 +26,17 @@ func TestRPC_Call(t *testing.T) {
 
 	addrs := []mino.Address{address{"A"}, address{"B"}}
 
-	msgs, errs := rpc.Call(context.Background(), fake.Message{}, mino.NewAddresses(addrs...))
-	select {
-	case err := <-errs:
-		t.Fatal(err)
-	case msg := <-msgs:
+	msgs, err := rpc.Call(context.Background(), fake.Message{}, mino.NewAddresses(addrs...))
+	require.NoError(t, err)
+
+	for i := 0; i < 2; i++ {
+		msg, more := <-msgs
+		require.True(t, more)
 		require.NotNil(t, msg)
 	}
+
+	_, more := <-msgs
+	require.False(t, more)
 }
 
 func TestRPC_Stream(t *testing.T) {

--- a/mino/response.go
+++ b/mino/response.go
@@ -1,0 +1,42 @@
+package mino
+
+import "go.dedis.ch/dela/serde"
+
+// SimpleResponse is a response that can either return a message, or an error if
+// the request has failed.
+//
+// - implements mino.Response
+type simpleResponse struct {
+	from Address
+	msg  serde.Message
+	err  error
+}
+
+// NewResponse creates a response that will return the message.
+func NewResponse(from Address, msg serde.Message) Response {
+	return simpleResponse{
+		from: from,
+		msg:  msg,
+	}
+}
+
+// NewResponseWithError creates a response that will return an error instead of
+// a message.
+func NewResponseWithError(from Address, err error) Response {
+	return simpleResponse{
+		from: from,
+		err:  err,
+	}
+}
+
+// GetFrom implements mino.Response. It returns the address the response
+// originates from.
+func (resp simpleResponse) GetFrom() Address {
+	return resp.from
+}
+
+// GetMessageOrError implements mino.Response. It returns either a message or an
+// error.
+func (resp simpleResponse) GetMessageOrError() (serde.Message, error) {
+	return resp.msg, resp.err
+}

--- a/mino/response_test.go
+++ b/mino/response_test.go
@@ -1,0 +1,33 @@
+package mino
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.dedis.ch/dela/serde"
+	"golang.org/x/xerrors"
+)
+
+func TestResponse_GetFrom(t *testing.T) {
+	resp := NewResponse(fakeAddr{}, fakeMsg{})
+
+	require.Equal(t, fakeAddr{}, resp.GetFrom())
+}
+
+func TestResponse_GetMessageOrError(t *testing.T) {
+	resp := NewResponse(fakeAddr{}, fakeMsg{})
+	msg, err := resp.GetMessageOrError()
+	require.NoError(t, err)
+	require.Equal(t, fakeMsg{}, msg)
+
+	resp = NewResponseWithError(fakeAddr{}, xerrors.New("oops"))
+	_, err = resp.GetMessageOrError()
+	require.EqualError(t, err, "oops")
+}
+
+// -----------------------------------------------------------------------------
+// Utility functions
+
+type fakeMsg struct {
+	serde.Message
+}


### PR DESCRIPTION
This fix the potential issue that occurs when an error is returned and the response channel is closed. The change makes sure that every error is read before closing.