### PR TITLE
Core: view change as a transaction

### DIFF
--- a/consensus/cosipbft/types/queue_test.go
+++ b/consensus/cosipbft/types/queue_test.go
@@ -101,10 +101,9 @@ func TestQueue_Finalize(t *testing.T) {
 		items: []item{
 			{
 				ForwardLink: ForwardLink{
-					from:      []byte{0xaa},
-					to:        []byte{0xbb},
-					prepare:   fake.Signature{},
-					changeset: fake.Message{},
+					from:    []byte{0xaa},
+					to:      []byte{0xbb},
+					prepare: fake.Signature{},
 				},
 				verifier: verifier,
 			},

--- a/consensus/viewchange/mod.go
+++ b/consensus/viewchange/mod.go
@@ -11,6 +11,8 @@ type ChangeSet interface {
 	serde.Message
 
 	NumChanges() int
+
+	GetNewAddresses() []mino.Address
 }
 
 type ChangeSetFactory interface {

--- a/consensus/viewchange/mod.go
+++ b/consensus/viewchange/mod.go
@@ -9,6 +9,8 @@ import (
 // ChangeSet is the return of a diff between two authorities.
 type ChangeSet interface {
 	serde.Message
+
+	NumChanges() int
 }
 
 type ChangeSetFactory interface {

--- a/consensus/viewchange/roster/changeset.go
+++ b/consensus/viewchange/roster/changeset.go
@@ -30,8 +30,21 @@ type ChangeSet struct {
 	Add    []Player
 }
 
+// NumChanges implements viewchange.ChangeSet. It returns the number of changes
+// that is applied with the change set.
 func (set ChangeSet) NumChanges() int {
 	return len(set.Remove) + len(set.Add)
+}
+
+// GetNewAddresses implements viewchange.ChangeSet. It returns the list of
+// addresses of the new members.
+func (set ChangeSet) GetNewAddresses() []mino.Address {
+	addrs := make([]mino.Address, len(set.Add))
+	for i, player := range set.Add {
+		addrs[i] = player.Address
+	}
+
+	return addrs
 }
 
 // Serialize implements serde.Message.

--- a/consensus/viewchange/roster/changeset.go
+++ b/consensus/viewchange/roster/changeset.go
@@ -30,6 +30,10 @@ type ChangeSet struct {
 	Add    []Player
 }
 
+func (set ChangeSet) NumChanges() int {
+	return len(set.Remove) + len(set.Add)
+}
+
 // Serialize implements serde.Message.
 func (set ChangeSet) Serialize(ctx serde.Context) ([]byte, error) {
 	format := csetFormats.Get(ctx.GetFormat())

--- a/core/execution/baremetal/mod.go
+++ b/core/execution/baremetal/mod.go
@@ -47,7 +47,7 @@ func (bm *BareMetal) Execute(tx txn.Transaction, snap store.Snapshot) (execution
 
 	contract := bm.contracts[name]
 	if contract == nil {
-		return execution.Result{}, xerrors.Errorf("unknwon contract '%s'", name)
+		return execution.Result{}, xerrors.Errorf("unknown contract '%s'", name)
 	}
 
 	res, err := contract.Execute(tx, snap)

--- a/core/execution/baremetal/mod.go
+++ b/core/execution/baremetal/mod.go
@@ -7,28 +7,50 @@ import (
 	"golang.org/x/xerrors"
 )
 
+const (
+	// ContractArg is the argument key in the transaction to look up a contract.
+	ContractArg = "go.dedis.ch/dela/core/execution/baremetal.ContractArg"
+)
+
+// Contract is the interface to implement to register a smart contract that will
+// be executed natively.
+type Contract interface {
+	Execute(txn.Transaction, store.Snapshot) (execution.Result, error)
+}
+
 // BareMetal is an execution service for packaged applications. Those
 // applications have complete access to the trie and can directly update it.
 //
 // - implements execution.Service
-//
-// TODO: extend to allow registration of other specialized bare-metal services.
 type BareMetal struct {
-	exec execution.Service
+	contracts map[string]Contract
 }
 
 // NewExecution returns a new bare-metal execution. The given service will be
 // executed for every incoming transaction.
-func NewExecution(exec execution.Service) BareMetal {
-	return BareMetal{
-		exec: exec,
+func NewExecution() *BareMetal {
+	return &BareMetal{
+		contracts: map[string]Contract{},
 	}
+}
+
+// Set stores the contract using the name as the key. A transaction can trigger
+// this contract by using the same name as the contract argument.
+func (bm *BareMetal) Set(name string, contract Contract) {
+	bm.contracts[name] = contract
 }
 
 // Execute implements execution.Service. It uses the executor to process the
 // incoming transaction and return the result.
-func (bm BareMetal) Execute(tx txn.Transaction, snap store.Snapshot) (execution.Result, error) {
-	res, err := bm.exec.Execute(tx, snap)
+func (bm *BareMetal) Execute(tx txn.Transaction, snap store.Snapshot) (execution.Result, error) {
+	name := string(tx.GetArg(ContractArg))
+
+	contract := bm.contracts[name]
+	if contract == nil {
+		return execution.Result{}, xerrors.Errorf("unknwon contract '%s'", name)
+	}
+
+	res, err := contract.Execute(tx, snap)
 	if err != nil {
 		return res, xerrors.Errorf("failed to execute: %v", err)
 	}

--- a/core/execution/baremetal/mod_test.go
+++ b/core/execution/baremetal/mod_test.go
@@ -11,14 +11,15 @@ import (
 )
 
 func TestBareMetal_Execute(t *testing.T) {
-	srvc := NewExecution(fakeExec{})
+	srvc := NewExecution()
+	srvc.Set("abc", fakeExec{})
+	srvc.Set("bad", fakeExec{err: xerrors.New("oops")})
 
-	res, err := srvc.Execute(nil, nil)
+	res, err := srvc.Execute(fakeTx{contract: "abc"}, nil)
 	require.NoError(t, err)
 	require.Equal(t, execution.Result{}, res)
 
-	srvc.exec = fakeExec{err: xerrors.New("oops")}
-	_, err = srvc.Execute(nil, nil)
+	_, err = srvc.Execute(fakeTx{contract: "bad"}, nil)
 	require.EqualError(t, err, "failed to execute: oops")
 }
 
@@ -31,4 +32,13 @@ type fakeExec struct {
 
 func (e fakeExec) Execute(txn.Transaction, store.Snapshot) (execution.Result, error) {
 	return execution.Result{}, e.err
+}
+
+type fakeTx struct {
+	txn.Transaction
+	contract string
+}
+
+func (tx fakeTx) GetArg(key string) []byte {
+	return []byte(tx.contract)
 }

--- a/core/execution/baremetal/mod_test.go
+++ b/core/execution/baremetal/mod_test.go
@@ -19,6 +19,9 @@ func TestBareMetal_Execute(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, execution.Result{}, res)
 
+	_, err = srvc.Execute(fakeTx{contract: "none"}, nil)
+	require.EqualError(t, err, "unknown contract 'none'")
+
 	_, err = srvc.Execute(fakeTx{contract: "bad"}, nil)
 	require.EqualError(t, err, "failed to execute: oops")
 }

--- a/core/execution/baremetal/viewchange/mod.go
+++ b/core/execution/baremetal/viewchange/mod.go
@@ -1,0 +1,83 @@
+package viewchange
+
+import (
+	"go.dedis.ch/dela/consensus/viewchange"
+	"go.dedis.ch/dela/core/execution"
+	"go.dedis.ch/dela/core/store"
+	"go.dedis.ch/dela/core/txn"
+	"go.dedis.ch/dela/serde"
+	"go.dedis.ch/dela/serde/json"
+	"golang.org/x/xerrors"
+)
+
+const (
+	// AuthorityArg is the key of the argument for the new roster.
+	AuthorityArg = "viewchange:authority"
+
+	messageArgMissing     = "authority not found in transaction"
+	messageStorageEmpty   = "authority not found in storage"
+	messageTooManyChanges = "too many changes"
+	messageStorageFailure = "storage failure"
+)
+
+// Contract is a contract to update the roster at a given key in the storage. It
+// only allows one member change per transaction.
+//
+// - implements baremetal.Contract
+type Contract struct {
+	rosterKey []byte
+	rosterFac viewchange.AuthorityFactory
+	context   serde.Context
+}
+
+// NewContract creates a new viewchange contract.
+func NewContract(key []byte, fac viewchange.AuthorityFactory) Contract {
+	return Contract{
+		rosterKey: key,
+		rosterFac: fac,
+		context:   json.NewContext(),
+	}
+}
+
+// Execute implements baremetal.Contract. It looks for the roster in the
+// transaction and updates the storage if there is at most one membership
+// change.
+func (c Contract) Execute(tx txn.Transaction, snap store.Snapshot) (execution.Result, error) {
+	res := execution.Result{}
+
+	roster, err := c.rosterFac.AuthorityOf(c.context, tx.GetArg(AuthorityArg))
+	if err != nil {
+		res.Message = messageArgMissing
+		return res, xerrors.Errorf("roster factory failed: %v", err)
+	}
+
+	currData, err := snap.Get(c.rosterKey)
+	if err != nil {
+		res.Message = messageStorageEmpty
+		return res, xerrors.Errorf("couldn't read roster: %v", err)
+	}
+
+	curr, err := c.rosterFac.AuthorityOf(c.context, currData)
+	if err != nil {
+		res.Message = messageStorageEmpty
+		return res, xerrors.Errorf("roster factory failed: %v", err)
+	}
+
+	changeset := curr.Diff(roster)
+
+	if changeset.NumChanges() > 1 {
+		res.Message = messageTooManyChanges
+		return res, xerrors.Errorf("only one change is expected but found %d", changeset.NumChanges())
+	}
+
+	// TODO: check the number of changes per batch instead of transaction wide.
+	// TODO: access rights control
+
+	err = snap.Set(c.rosterKey, tx.GetArg(AuthorityArg))
+	if err != nil {
+		res.Message = messageStorageFailure
+		return res, xerrors.Errorf("couldn't store authority: %v", err)
+	}
+
+	return res, nil
+}

--- a/core/execution/baremetal/viewchange/mod.go
+++ b/core/execution/baremetal/viewchange/mod.go
@@ -17,10 +17,11 @@ const (
 	// AuthorityArg is the key of the argument for the new roster.
 	AuthorityArg = "viewchange:authority"
 
-	messageArgMissing     = "authority not found in transaction"
-	messageStorageEmpty   = "authority not found in storage"
-	messageTooManyChanges = "too many changes"
-	messageStorageFailure = "storage failure"
+	messageArgMissing       = "authority not found in transaction"
+	messageStorageEmpty     = "authority not found in storage"
+	messageStorageCorrupted = "invalid authority data in storage"
+	messageTooManyChanges   = "too many changes"
+	messageStorageFailure   = "storage failure"
 )
 
 // Contract is a contract to update the roster at a given key in the storage. It
@@ -62,7 +63,7 @@ func (c Contract) Execute(tx txn.Transaction, snap store.Snapshot) (execution.Re
 
 	curr, err := c.rosterFac.AuthorityOf(c.context, currData)
 	if err != nil {
-		res.Message = messageStorageEmpty
+		res.Message = messageStorageCorrupted
 		return res, xerrors.Errorf("failed to decode roster: %v", err)
 	}
 

--- a/core/execution/baremetal/viewchange/mod.go
+++ b/core/execution/baremetal/viewchange/mod.go
@@ -51,19 +51,19 @@ func (c Contract) Execute(tx txn.Transaction, snap store.Snapshot) (execution.Re
 	roster, err := c.rosterFac.AuthorityOf(c.context, tx.GetArg(AuthorityArg))
 	if err != nil {
 		res.Message = messageArgMissing
-		return res, xerrors.Errorf("roster factory failed: %v", err)
+		return res, xerrors.Errorf("failed to decode arg: %v", err)
 	}
 
 	currData, err := snap.Get(c.rosterKey)
 	if err != nil {
 		res.Message = messageStorageEmpty
-		return res, xerrors.Errorf("couldn't read roster: %v", err)
+		return res, xerrors.Errorf("failed to read roster: %v", err)
 	}
 
 	curr, err := c.rosterFac.AuthorityOf(c.context, currData)
 	if err != nil {
 		res.Message = messageStorageEmpty
-		return res, xerrors.Errorf("roster factory failed: %v", err)
+		return res, xerrors.Errorf("failed to decode roster: %v", err)
 	}
 
 	changeset := curr.Diff(roster)
@@ -79,8 +79,10 @@ func (c Contract) Execute(tx txn.Transaction, snap store.Snapshot) (execution.Re
 	err = snap.Set(c.rosterKey, tx.GetArg(AuthorityArg))
 	if err != nil {
 		res.Message = messageStorageFailure
-		return res, xerrors.Errorf("couldn't store authority: %v", err)
+		return res, xerrors.Errorf("failed to store roster: %v", err)
 	}
+
+	res.Accepted = true
 
 	return res, nil
 }

--- a/core/execution/baremetal/viewchange/mod.go
+++ b/core/execution/baremetal/viewchange/mod.go
@@ -11,6 +11,9 @@ import (
 )
 
 const (
+	// ContractName is the name of the contract.
+	ContractName = "go.dedis.ch/dela/core/execution/baremetal/viewchange.Contract"
+
 	// AuthorityArg is the key of the argument for the new roster.
 	AuthorityArg = "viewchange:authority"
 

--- a/core/execution/baremetal/viewchange/mod_test.go
+++ b/core/execution/baremetal/viewchange/mod_test.go
@@ -39,7 +39,7 @@ func TestContract_Execute(t *testing.T) {
 	res, err = contract.Execute(makeTx(t, "[]"), fakeStore{})
 	require.EqualError(t, err, "failed to decode roster: oops")
 	require.False(t, res.Accepted)
-	require.Equal(t, messageStorageEmpty, res.Message)
+	require.Equal(t, messageStorageCorrupted, res.Message)
 
 	contract.rosterFac = fac
 	res, err = contract.Execute(makeTx(t, "[{},{}]"), fakeStore{})

--- a/core/execution/baremetal/viewchange/mod_test.go
+++ b/core/execution/baremetal/viewchange/mod_test.go
@@ -1,0 +1,92 @@
+package viewchange
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.dedis.ch/dela/consensus/viewchange"
+	"go.dedis.ch/dela/consensus/viewchange/roster"
+	"go.dedis.ch/dela/core/store"
+	"go.dedis.ch/dela/core/txn"
+	"go.dedis.ch/dela/core/txn/anon"
+	"go.dedis.ch/dela/internal/testing/fake"
+	"go.dedis.ch/dela/serde"
+	"golang.org/x/xerrors"
+)
+
+func TestContract_Execute(t *testing.T) {
+	fac := roster.NewFactory(fake.AddressFactory{}, fake.PublicKeyFactory{})
+
+	contract := NewContract([]byte("abc"), fac)
+
+	res, err := contract.Execute(makeTx(t, "[]"), fakeStore{})
+	require.NoError(t, err)
+	require.True(t, res.Accepted)
+
+	contract.rosterFac = badRosterFac{}
+	res, err = contract.Execute(makeTx(t, "[]"), fakeStore{})
+	require.EqualError(t, err, "failed to decode arg: oops")
+	require.False(t, res.Accepted)
+	require.Equal(t, messageArgMissing, res.Message)
+
+	contract.rosterFac = fac
+	res, err = contract.Execute(makeTx(t, "[]"), fakeStore{errGet: xerrors.New("oops")})
+	require.EqualError(t, err, "failed to read roster: oops")
+	require.False(t, res.Accepted)
+	require.Equal(t, messageStorageEmpty, res.Message)
+
+	contract.rosterFac = badRosterFac{counter: fake.NewCounter(1)}
+	res, err = contract.Execute(makeTx(t, "[]"), fakeStore{})
+	require.EqualError(t, err, "failed to decode roster: oops")
+	require.False(t, res.Accepted)
+	require.Equal(t, messageStorageEmpty, res.Message)
+
+	contract.rosterFac = fac
+	res, err = contract.Execute(makeTx(t, "[{},{}]"), fakeStore{})
+	require.EqualError(t, err, "only one change is expected but found 2")
+	require.False(t, res.Accepted)
+	require.Equal(t, messageTooManyChanges, res.Message)
+
+	res, err = contract.Execute(makeTx(t, "[]"), fakeStore{errSet: xerrors.New("oops")})
+	require.EqualError(t, err, "failed to store roster: oops")
+	require.False(t, res.Accepted)
+	require.Equal(t, messageStorageFailure, res.Message)
+}
+
+// Utility functions -----------------------------------------------------------
+
+func makeTx(t *testing.T, arg string) txn.Transaction {
+	tx, err := anon.NewTransaction(0, anon.WithArg(AuthorityArg, []byte(arg)))
+	require.NoError(t, err)
+
+	return tx
+}
+
+type fakeStore struct {
+	store.Snapshot
+
+	errGet error
+	errSet error
+}
+
+func (snap fakeStore) Get(key []byte) ([]byte, error) {
+	return []byte("[]"), snap.errGet
+}
+
+func (snap fakeStore) Set(key, value []byte) error {
+	return snap.errSet
+}
+
+type badRosterFac struct {
+	viewchange.AuthorityFactory
+	counter *fake.Counter
+}
+
+func (fac badRosterFac) AuthorityOf(serde.Context, []byte) (viewchange.Authority, error) {
+	if fac.counter.Done() {
+		return nil, xerrors.New("oops")
+	}
+
+	fac.counter.Decrease()
+	return nil, nil
+}

--- a/core/ordering/cosipbft/blockstore/mem_test.go
+++ b/core/ordering/cosipbft/blockstore/mem_test.go
@@ -88,6 +88,10 @@ func TestInMemory_Watch(t *testing.T) {
 
 	link := <-ch
 	require.Equal(t, types.Digest{}, link.GetFrom())
+
+	cancel()
+	_, more := <-ch
+	require.False(t, more)
 }
 
 // Utility functions -----------------------------------------------------------

--- a/core/ordering/cosipbft/blockstore/mem_test.go
+++ b/core/ordering/cosipbft/blockstore/mem_test.go
@@ -96,7 +96,7 @@ func makeLink(t *testing.T, from types.Digest, opts ...types.BlockOption) types.
 	to, err := types.NewBlock(simple.NewData(nil), opts...)
 	require.NoError(t, err)
 
-	link := types.NewBlockLink(from, to, nil, nil)
+	link := types.NewBlockLink(from, to, nil, nil, nil)
 
 	return link
 }

--- a/core/ordering/cosipbft/blocksync/types/mod_test.go
+++ b/core/ordering/cosipbft/blocksync/types/mod_test.go
@@ -51,7 +51,7 @@ func TestSyncRequest_Serialize(t *testing.T) {
 }
 
 func TestSyncReply_GetLink(t *testing.T) {
-	link := types.NewBlockLink(types.Digest{1}, types.Block{}, nil, nil)
+	link := types.NewBlockLink(types.Digest{1}, types.Block{}, nil, nil, nil)
 
 	m := NewSyncReply(link)
 
@@ -59,7 +59,7 @@ func TestSyncReply_GetLink(t *testing.T) {
 }
 
 func TestSyncReply_Serialize(t *testing.T) {
-	m := NewSyncReply(types.NewBlockLink(types.Digest{}, types.Block{}, nil, nil))
+	m := NewSyncReply(types.NewBlockLink(types.Digest{}, types.Block{}, nil, nil, nil))
 
 	data, err := m.Serialize(fake.NewContext())
 	require.NoError(t, err)
@@ -83,7 +83,7 @@ func TestSyncAck_Serialize(t *testing.T) {
 func TestMessageFactory_Deserialize(t *testing.T) {
 	testCalls.Clear()
 
-	fac := NewMessageFactory(types.NewBlockLinkFactory(nil, nil))
+	fac := NewMessageFactory(types.NewBlockLinkFactory(nil, nil, nil))
 
 	msg, err := fac.Deserialize(fake.NewContext(), nil)
 	require.NoError(t, err)

--- a/core/ordering/cosipbft/json/mod.go
+++ b/core/ordering/cosipbft/json/mod.go
@@ -33,6 +33,7 @@ type BlockLinkJSON struct {
 	Block            json.RawMessage
 	PrepareSignature json.RawMessage
 	CommitSignature  json.RawMessage
+	ChangeSet        json.RawMessage
 }
 
 type GenesisMessageJSON struct {

--- a/core/ordering/cosipbft/mod_test.go
+++ b/core/ordering/cosipbft/mod_test.go
@@ -168,6 +168,8 @@ type testNode struct {
 	dbpath  string
 }
 
+const testContractName = "abc"
+
 type testExec struct {
 	err error
 }
@@ -177,7 +179,7 @@ func (e testExec) Execute(txn.Transaction, store.Snapshot) (execution.Result, er
 }
 
 func makeTx(t *testing.T, nonce uint64) txn.Transaction {
-	tx, err := anon.NewTransaction(nonce)
+	tx, err := anon.NewTransaction(nonce, anon.WithArg(baremetal.ContractArg, []byte(testContractName)))
 	require.NoError(t, err)
 	return tx
 }
@@ -221,7 +223,10 @@ func makeAuthority(t *testing.T, n int) ([]testNode, crypto.CollectiveAuthority,
 
 		tree := binprefix.NewMerkleTree(db, binprefix.Nonce{})
 
-		vs := simple.NewService(baremetal.NewExecution(testExec{}), anon.NewTransactionFactory())
+		exec := baremetal.NewExecution()
+		exec.Set(testContractName, testExec{})
+
+		vs := simple.NewService(exec, anon.NewTransactionFactory())
 
 		param := ServiceParam{
 			Mino:       m,

--- a/core/ordering/cosipbft/mod_test.go
+++ b/core/ordering/cosipbft/mod_test.go
@@ -102,7 +102,7 @@ func TestService_ViewChange_DoRound(t *testing.T) {
 	rpc.Done()
 
 	go func() {
-		ch <- pbft.PrePrepareState
+		ch <- pbft.InitialState
 		close(ch)
 		srvc.Close()
 	}()
@@ -111,11 +111,8 @@ func TestService_ViewChange_DoRound(t *testing.T) {
 	require.NoError(t, err)
 
 	srvc.closing = make(chan struct{})
-	srvc.pbftsm = fakeSM{err: xerrors.New("oops")}
-	err = srvc.doRound()
-	require.EqualError(t, err, "pbft pre-prepare failed: oops")
 
-	srvc.pbftsm = fakeSM{err: xerrors.New("oops"), state: pbft.PrePrepareState}
+	srvc.pbftsm = fakeSM{err: xerrors.New("oops"), state: pbft.InitialState}
 	err = srvc.doRound()
 	require.EqualError(t, err, "pbft expire failed: oops")
 

--- a/core/ordering/cosipbft/pbft/mod_test.go
+++ b/core/ordering/cosipbft/pbft/mod_test.go
@@ -1,12 +1,14 @@
 package pbft
 
 import (
+	"bytes"
 	"context"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 	"go.dedis.ch/dela/blockchain"
 	"go.dedis.ch/dela/consensus/viewchange"
@@ -25,6 +27,11 @@ import (
 	"golang.org/x/xerrors"
 )
 
+func TestState_String(t *testing.T) {
+	var state State = 99
+	require.Equal(t, "none", state.String())
+}
+
 func TestStateMachine_GetState(t *testing.T) {
 	sm := &pbftsm{}
 
@@ -35,47 +42,43 @@ func TestStateMachine_GetState(t *testing.T) {
 }
 
 func TestStateMachine_GetLeader(t *testing.T) {
-	sm := &pbftsm{}
-
-	leader := sm.GetLeader()
-	require.Nil(t, leader)
-
 	authority := fake.NewAuthority(3, fake.NewSigner)
 
-	sm.round.roster = roster.FromAuthority(authority)
-	leader = sm.GetLeader()
+	sm := &pbftsm{
+		tree: blockstore.NewTreeCache(badTree{}),
+		authReader: func(hashtree.Tree) (viewchange.Authority, error) {
+			return roster.FromAuthority(authority), nil
+		},
+	}
+
+	leader, err := sm.GetLeader()
+	require.NoError(t, err)
 	require.Equal(t, authority.GetAddress(0), leader)
 
 	sm.round.leader = 2
-	leader = sm.GetLeader()
-	require.Equal(t, authority.GetAddress(2), leader)
-}
-
-func TestStateMachine_PrePrepare(t *testing.T) {
-	sm := &pbftsm{
-		watcher: blockchain.NewWatcher(),
-	}
-
-	ro := roster.FromAuthority(fake.NewAuthority(4, fake.NewSigner))
-
-	err := sm.PrePrepare(ro)
+	leader, err = sm.GetLeader()
 	require.NoError(t, err)
-	require.Equal(t, 2, sm.round.threshold)
-	require.Equal(t, ro, sm.round.roster)
+	require.Equal(t, authority.GetAddress(2), leader)
 
-	err = sm.PrePrepare(ro)
-	require.EqualError(t, err, "mismatch state preprepare != initial")
+	sm.authReader = badReader
+	_, err = sm.GetLeader()
+	require.EqualError(t, err, "failed to read roster: oops")
 }
 
 func TestStateMachine_Prepare(t *testing.T) {
 	tree, clean := makeTree(t)
 	defer clean()
 
+	ro := roster.FromAuthority(fake.NewAuthority(3, fake.NewSigner))
+
 	param := StateMachineParam{
 		Validation: simple.NewService(fakeExec{}, nil),
 		Blocks:     blockstore.NewInMemory(),
 		Genesis:    blockstore.NewGenesisStore(),
 		Tree:       blockstore.NewTreeCache(tree),
+		AuthorityReader: func(hashtree.Tree) (viewchange.Authority, error) {
+			return ro, nil
+		},
 	}
 
 	param.Genesis.Set(types.Genesis{})
@@ -87,7 +90,7 @@ func TestStateMachine_Prepare(t *testing.T) {
 	require.NoError(t, err)
 
 	sm := NewStateMachine(param).(*pbftsm)
-	sm.state = PrePrepareState
+	sm.state = InitialState
 
 	id, err := sm.Prepare(block)
 	require.NoError(t, err)
@@ -101,9 +104,9 @@ func TestStateMachine_Prepare(t *testing.T) {
 
 	sm.state = ViewChangeState
 	_, err = sm.Prepare(block)
-	require.EqualError(t, err, "mismatch state viewchange != preprepare")
+	require.EqualError(t, err, "mismatch state viewchange != initial")
 
-	sm.state = PrePrepareState
+	sm.state = InitialState
 	sm.val = badValidation{}
 	_, err = sm.Prepare(block)
 	require.EqualError(t, err, "tree failed: callback failed: validation failed: oops")
@@ -119,7 +122,17 @@ func TestStateMachine_Prepare(t *testing.T) {
 	_, err = sm.Prepare(block)
 	require.EqualError(t, err, "couldn't get latest digest: missing genesis block")
 
+	// Failure to read the roster of the round.
 	sm.genesis.Set(types.Genesis{})
+	sm.authReader = badReader
+	_, err = sm.Prepare(block)
+	require.EqualError(t, err, "failed to read roster: oops")
+
+	// Failure to read the roster of the staging tree.
+	err = sm.verifyPrepare(tree, block, &sm.round, ro)
+	require.EqualError(t, err, "failed to read next roster: oops")
+
+	sm.authReader = param.AuthorityReader
 	sm.hashFac = fake.NewHashFactory(fake.NewBadHash())
 	_, err = sm.Prepare(block)
 	require.EqualError(t, err, "couldn't fingerprint link: couldn't write from: fake error")
@@ -130,6 +143,10 @@ func TestStateMachine_Commit(t *testing.T) {
 		state:       PrepareState,
 		verifierFac: fake.NewVerifierFactory(fake.Verifier{}),
 		watcher:     blockchain.NewWatcher(),
+		tree:        blockstore.NewTreeCache(badTree{}),
+		authReader: func(hashtree.Tree) (viewchange.Authority, error) {
+			return roster.New(nil, nil), nil
+		},
 	}
 	sm.round.id = types.Digest{1}
 
@@ -154,6 +171,11 @@ func TestStateMachine_Commit(t *testing.T) {
 	sm.verifierFac = fake.NewVerifierFactory(fake.NewBadVerifier())
 	err = sm.Commit(types.Digest{1}, fake.Signature{})
 	require.EqualError(t, err, "verifier failed: fake error")
+
+	sm.verifierFac = fake.NewVerifierFactory(fake.Verifier{})
+	sm.authReader = badReader
+	err = sm.Commit(types.Digest{1}, fake.Signature{})
+	require.EqualError(t, err, "failed to read roster: oops")
 }
 
 func TestStateMachine_Finalize(t *testing.T) {
@@ -178,7 +200,6 @@ func TestStateMachine_Finalize(t *testing.T) {
 	sm.state = CommitState
 	sm.round.tree = tree.(hashtree.StagingTree)
 	sm.round.prepareSig = fake.Signature{}
-	sm.round.roster = ro
 
 	err := sm.Finalize(types.Digest{1}, fake.Signature{})
 	require.NoError(t, err)
@@ -201,6 +222,27 @@ func TestStateMachine_Finalize(t *testing.T) {
 	sm.blocks = blockstore.NewInMemory()
 	err = sm.Finalize(types.Digest{1}, fake.Signature{})
 	require.EqualError(t, err, "couldn't get latest digest: missing genesis block")
+
+	sm.blocks = badBlockStore{length: 1}
+	err = sm.Finalize(types.Digest{1}, fake.Signature{})
+	require.EqualError(t, err, "couldn't get latest digest: oops")
+
+	sm.blocks = blockstore.NewInMemory()
+	sm.blocks.Store(makeLink(t))
+	sm.round.tree = badTree{}
+	err = sm.Finalize(types.Digest{1}, fake.Signature{})
+	require.EqualError(t, err, "commit tree failed: oops")
+
+	sm.blocks = badBlockStore{}
+	sm.genesis.Set(types.Genesis{})
+	sm.round.tree = tree.(hashtree.StagingTree)
+	err = sm.Finalize(types.Digest{1}, fake.Signature{})
+	require.EqualError(t, err, "failed to store block: oops")
+
+	sm.blocks = blockstore.NewInMemory()
+	sm.authReader = badReader
+	err = sm.Finalize(types.Digest{1}, fake.Signature{})
+	require.EqualError(t, err, "failed to read roster: oops")
 }
 
 func TestStateMachine_Accept(t *testing.T) {
@@ -212,11 +254,20 @@ func TestStateMachine_Accept(t *testing.T) {
 	sm.Accept(View{From: fake.NewAddress(1), Leader: 1})
 	require.Len(t, sm.round.views, 2)
 
+	// Ignore duplicate.
 	sm.Accept(View{From: fake.NewAddress(0), Leader: 1})
 	require.Len(t, sm.round.views, 2)
 
+	// Ignore views for a different leader.
 	sm.Accept(View{From: fake.NewAddress(2), Leader: 5})
 	require.Len(t, sm.round.views, 2)
+
+	// Only accept views for the current round ID.
+	buffer := new(bytes.Buffer)
+	sm.logger = zerolog.New(buffer)
+	sm.Accept(View{From: fake.NewAddress(3), Leader: 1, ID: types.Digest{1}})
+	require.Len(t, sm.round.views, 2)
+	require.Contains(t, buffer.String(), "received a view for a different block")
 }
 
 func TestStateMachine_AcceptAll(t *testing.T) {
@@ -231,7 +282,11 @@ func TestStateMachine_AcceptAll(t *testing.T) {
 		{From: fake.NewAddress(2), Leader: 5},
 	})
 	require.Equal(t, 5, sm.round.leader)
-	require.Equal(t, PrePrepareState, sm.state)
+	require.Equal(t, InitialState, sm.state)
+
+	// Only accept if there are enough views.
+	sm.AcceptAll([]View{{Leader: 6}})
+	require.Equal(t, 5, sm.round.leader)
 }
 
 func TestStateMachine_Expire(t *testing.T) {
@@ -278,7 +333,6 @@ func TestStateMachine_CatchUp(t *testing.T) {
 	require.NoError(t, err)
 
 	sm := NewStateMachine(param).(*pbftsm)
-	sm.round.roster = ro
 
 	link := types.NewBlockLink(types.Digest{}, block, fake.Signature{}, fake.Signature{}, roster.ChangeSet{})
 
@@ -288,6 +342,11 @@ func TestStateMachine_CatchUp(t *testing.T) {
 	err = sm.CatchUp(link)
 	require.EqualError(t, err, "prepare failed: mismatch index 1 != 2")
 
+	sm.authReader = badReader
+	err = sm.CatchUp(link)
+	require.EqualError(t, err, "failed to read roster: oops")
+
+	sm.authReader = param.AuthorityReader
 	sm.blocks = blockstore.NewInMemory()
 	sm.verifierFac = fake.NewVerifierFactory(fake.NewBadVerifier())
 	err = sm.CatchUp(link)
@@ -334,6 +393,13 @@ func makeTree(t *testing.T) (hashtree.Tree, func()) {
 	return stage, func() { os.RemoveAll(dir) }
 }
 
+func makeLink(t *testing.T) types.BlockLink {
+	block, err := types.NewBlock(simple.NewData(nil))
+	require.NoError(t, err)
+
+	return types.NewBlockLink(types.Digest{}, block, nil, nil, roster.ChangeSet{})
+}
+
 type fakeExec struct {
 	err error
 }
@@ -347,5 +413,34 @@ type badValidation struct {
 }
 
 func (v badValidation) Validate(store.Snapshot, []txn.Transaction) (validation.Data, error) {
+	return nil, xerrors.New("oops")
+}
+
+type badBlockStore struct {
+	blockstore.BlockStore
+	length uint64
+}
+
+func (s badBlockStore) Len() uint64 {
+	return s.length
+}
+
+func (s badBlockStore) Last() (types.BlockLink, error) {
+	return nil, xerrors.New("oops")
+}
+
+func (s badBlockStore) Store(types.BlockLink) error {
+	return xerrors.New("oops")
+}
+
+type badTree struct {
+	hashtree.StagingTree
+}
+
+func (t badTree) Commit() (hashtree.Tree, error) {
+	return nil, xerrors.New("oops")
+}
+
+func badReader(hashtree.Tree) (viewchange.Authority, error) {
 	return nil, xerrors.New("oops")
 }

--- a/core/ordering/cosipbft/proc.go
+++ b/core/ordering/cosipbft/proc.go
@@ -65,7 +65,7 @@ func (h *processor) Invoke(from mino.Address, msg serde.Message) ([]byte, error)
 
 		blocks := h.blocks.Watch(ctx)
 
-		// In case the node is falling behing the chain, it gives it a chance to
+		// In case the node is falling behind the chain, it gives it a chance to
 		// catch up before moving forward.
 		if h.sync.GetLatest() > h.blocks.Len() {
 			for link := range blocks {

--- a/core/ordering/cosipbft/proc.go
+++ b/core/ordering/cosipbft/proc.go
@@ -2,7 +2,6 @@ package cosipbft
 
 import (
 	"context"
-	"time"
 
 	"github.com/rs/zerolog"
 	"go.dedis.ch/dela/blockchain"
@@ -61,7 +60,7 @@ func newProcessor() *processor {
 func (h *processor) Invoke(from mino.Address, msg serde.Message) ([]byte, error) {
 	switch in := msg.(type) {
 	case types.BlockMessage:
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
 		blocks := h.blocks.Watch(ctx)

--- a/core/ordering/cosipbft/proc_test.go
+++ b/core/ordering/cosipbft/proc_test.go
@@ -113,7 +113,7 @@ func TestProcessor_DoneMessage_Process(t *testing.T) {
 	proc := newProcessor()
 	proc.pbftsm = fakeSM{}
 	proc.blocks = blockstore.NewInMemory()
-	proc.blocks.Store(types.NewBlockLink(types.Digest{}, block, nil, nil))
+	proc.blocks.Store(types.NewBlockLink(types.Digest{}, block, nil, nil, nil))
 
 	req := mino.Request{
 		Message: types.NewDone(types.Digest{}, fake.Signature{}),

--- a/core/ordering/cosipbft/proc_test.go
+++ b/core/ordering/cosipbft/proc_test.go
@@ -143,10 +143,11 @@ func TestProcessor_Unsupported_Process(t *testing.T) {
 type fakeSM struct {
 	pbft.StateMachine
 
-	err   error
-	state pbft.State
-	id    types.Digest
-	ch    chan pbft.State
+	err       error
+	errLeader error
+	state     pbft.State
+	id        types.Digest
+	ch        chan pbft.State
 }
 
 func (sm fakeSM) GetState() pbft.State {
@@ -154,7 +155,7 @@ func (sm fakeSM) GetState() pbft.State {
 }
 
 func (sm fakeSM) GetLeader() (mino.Address, error) {
-	return fake.NewAddress(0), nil
+	return fake.NewAddress(0), sm.errLeader
 }
 
 func (sm fakeSM) PrePrepare(viewchange.Authority) error {
@@ -189,6 +190,13 @@ type fakeSync struct {
 
 func (sync fakeSync) GetLatest() uint64 {
 	return 0
+}
+
+func (sync fakeSync) Sync(ctx context.Context, players mino.Players) <-chan blocksync.Event {
+	ch := make(chan blocksync.Event, 1)
+	ch <- blocksync.Event{Hard: 999}
+
+	return ch
 }
 
 type fakeSnapshot struct {

--- a/core/ordering/cosipbft/types/block_test.go
+++ b/core/ordering/cosipbft/types/block_test.go
@@ -140,7 +140,7 @@ func TestBlockLink_GetChangeSet(t *testing.T) {
 }
 
 func TestBlockLink_Fingerprint(t *testing.T) {
-	link := NewBlockLink(Digest{}, Block{digest: Digest{}}, nil, nil)
+	link := NewBlockLink(Digest{}, Block{digest: Digest{}}, nil, nil, nil)
 
 	buffer := new(bytes.Buffer)
 
@@ -167,7 +167,7 @@ func TestBlockLink_Serialize(t *testing.T) {
 }
 
 func TestBlockLinkFac_Deserialize(t *testing.T) {
-	fac := NewBlockLinkFactory(BlockFactory{}, fake.SignatureFactory{})
+	fac := NewBlockLinkFactory(BlockFactory{}, fake.SignatureFactory{}, roster.NewChangeSetFactory(fake.AddressFactory{}, fake.PublicKeyFactory{}))
 
 	msg, err := fac.Deserialize(fake.NewContext(), nil)
 	require.NoError(t, err)

--- a/core/ordering/cosipbft/types/messages.go
+++ b/core/ordering/cosipbft/types/messages.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"go.dedis.ch/dela/consensus/viewchange"
 	"go.dedis.ch/dela/crypto"
 	"go.dedis.ch/dela/serde"
 	"go.dedis.ch/dela/serde/registry"
@@ -202,14 +203,16 @@ type MessageFactory struct {
 	genesisFac serde.Factory
 	blockFac   serde.Factory
 	sigFac     crypto.SignatureFactory
+	csFac      viewchange.ChangeSetFactory
 }
 
 // NewMessageFactory creates a new message factory.
-func NewMessageFactory(gf, bf serde.Factory, sf crypto.SignatureFactory) MessageFactory {
+func NewMessageFactory(gf, bf serde.Factory, sf crypto.SignatureFactory, csf viewchange.ChangeSetFactory) MessageFactory {
 	return MessageFactory{
 		genesisFac: gf,
 		blockFac:   bf,
 		sigFac:     sf,
+		csFac:      csf,
 	}
 }
 
@@ -220,7 +223,7 @@ func (f MessageFactory) Deserialize(ctx serde.Context, data []byte) (serde.Messa
 	ctx = serde.WithFactory(ctx, GenesisKey{}, f.genesisFac)
 	ctx = serde.WithFactory(ctx, BlockKey{}, f.blockFac)
 	ctx = serde.WithFactory(ctx, SignatureKey{}, f.sigFac)
-	ctx = serde.WithFactory(ctx, BlockLinkKey{}, NewBlockLinkFactory(f.blockFac, f.sigFac))
+	ctx = serde.WithFactory(ctx, BlockLinkKey{}, NewBlockLinkFactory(f.blockFac, f.sigFac, f.csFac))
 
 	msg, err := format.Decode(ctx, data)
 	if err != nil {

--- a/core/ordering/cosipbft/types/messages.go
+++ b/core/ordering/cosipbft/types/messages.go
@@ -48,6 +48,7 @@ func (m GenesisMessage) Serialize(ctx serde.Context) ([]byte, error) {
 // BlockMessage is a message sent to participants to share a block.
 type BlockMessage struct {
 	block Block
+	// TODO: include view change messages if appropriate.
 }
 
 // NewBlockMessage creates a new block message with the provided block.

--- a/core/ordering/cosipbft/types/messages_test.go
+++ b/core/ordering/cosipbft/types/messages_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.dedis.ch/dela/consensus/viewchange/roster"
 	"go.dedis.ch/dela/internal/testing/fake"
 )
 
@@ -118,7 +119,7 @@ func TestViewMessage_Serialize(t *testing.T) {
 }
 
 func TestMessageFactory_Deserialize(t *testing.T) {
-	fac := NewMessageFactory(GenesisFactory{}, BlockFactory{}, fake.SignatureFactory{})
+	fac := NewMessageFactory(GenesisFactory{}, BlockFactory{}, fake.SignatureFactory{}, roster.NewChangeSetFactory(fake.AddressFactory{}, fake.PublicKeyFactory{}))
 
 	msg, err := fac.Deserialize(fake.NewContext(), nil)
 	require.NoError(t, err)

--- a/core/ordering/cosipbft/types/mod.go
+++ b/core/ordering/cosipbft/types/mod.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"go.dedis.ch/dela/consensus/viewchange"
 	"go.dedis.ch/dela/crypto"
 	"go.dedis.ch/dela/serde"
 )
@@ -18,6 +19,8 @@ type BlockLink interface {
 	GetPrepareSignature() crypto.Signature
 
 	GetCommitSignature() crypto.Signature
+
+	GetChangeSet() viewchange.ChangeSet
 }
 
 // BlockLinkFactory is the interface of the block link factory.

--- a/core/ordering/pow/mod_test.go
+++ b/core/ordering/pow/mod_test.go
@@ -26,10 +26,13 @@ func TestService_Basic(t *testing.T) {
 	tree, clean := makeTree(t)
 	defer clean()
 
+	exec := baremetal.NewExecution()
+	exec.Set(testContractName, testExec{})
+
 	pool := pool.NewPool()
 	srvc := NewService(
 		pool,
-		val.NewService(baremetal.NewExecution(testExec{}), anon.NewTransactionFactory()),
+		val.NewService(exec, anon.NewTransactionFactory()),
 		tree,
 	)
 
@@ -66,7 +69,7 @@ func TestService_Listen(t *testing.T) {
 	tree, clean := makeTree(t)
 	defer clean()
 
-	vs := val.NewService(baremetal.NewExecution(testExec{}), anon.NewTransactionFactory())
+	vs := val.NewService(baremetal.NewExecution(), anon.NewTransactionFactory())
 
 	pool := pool.NewPool()
 	srvc := NewService(pool, vs, tree)
@@ -116,6 +119,8 @@ func TestService_GetProof(t *testing.T) {
 // -----------------------------------------------------------------------------
 // Utility functions
 
+const testContractName = "abc"
+
 func makeTree(t *testing.T) (hashtree.Tree, func()) {
 	dir, err := ioutil.TempDir(os.TempDir(), "dela-pow")
 	require.NoError(t, err)
@@ -130,7 +135,12 @@ func makeTree(t *testing.T) (hashtree.Tree, func()) {
 }
 
 func makeTx(t *testing.T, nonce uint64) txn.Transaction {
-	tx, err := anon.NewTransaction(nonce, anon.WithArg("key", []byte("ping")), anon.WithArg("value", []byte("pong")))
+	tx, err := anon.NewTransaction(
+		nonce,
+		anon.WithArg("key", []byte("ping")),
+		anon.WithArg("value", []byte("pong")),
+		anon.WithArg(baremetal.ContractArg, []byte(testContractName)),
+	)
 	require.NoError(t, err)
 
 	return tx


### PR DESCRIPTION
This adds an execution service to change the roster through transactions.