### PR TITLE
Core: pbft view are now signed

### DIFF
--- a/cli/node/memcoin/mod_test.go
+++ b/cli/node/memcoin/mod_test.go
@@ -106,7 +106,7 @@ func TestMemcoin_Scenario_1(t *testing.T) {
 // Utility functions
 
 func waitDaemon(t *testing.T, daemons []string) {
-	num := 20
+	num := 50
 
 	for _, daemon := range daemons {
 		for i := 0; i < num; i++ {

--- a/core/ordering/cosipbft/json/link.go
+++ b/core/ordering/cosipbft/json/link.go
@@ -87,12 +87,12 @@ func (fmt linkFormat) Decode(ctx serde.Context, data []byte) (serde.Message, err
 		return nil, xerrors.Errorf("failed to unmarshal: %v", err)
 	}
 
-	prepare, err := decodeSignature(ctx, m.PrepareSignature)
+	prepare, err := decodeSignature(ctx, m.PrepareSignature, types.AggregateKey{})
 	if err != nil {
 		return nil, xerrors.Errorf("failed to decode prepare: %v", err)
 	}
 
-	commit, err := decodeSignature(ctx, m.CommitSignature)
+	commit, err := decodeSignature(ctx, m.CommitSignature, types.AggregateKey{})
 	if err != nil {
 		return nil, xerrors.Errorf("failed to decode commit: %v", err)
 	}

--- a/core/ordering/cosipbft/json/link_test.go
+++ b/core/ordering/cosipbft/json/link_test.go
@@ -61,7 +61,7 @@ func TestLinkFormat_Decode(t *testing.T) {
 	format := linkFormat{}
 
 	ctx := fake.NewContext()
-	ctx = serde.WithFactory(ctx, types.SignatureKey{}, fake.SignatureFactory{})
+	ctx = serde.WithFactory(ctx, types.AggregateKey{}, fake.SignatureFactory{})
 	ctx = serde.WithFactory(ctx, types.ChangeSetKey{}, fakeChangeSetFac{})
 	ctx = serde.WithFactory(ctx, types.BlockKey{}, types.BlockFactory{})
 
@@ -76,11 +76,11 @@ func TestLinkFormat_Decode(t *testing.T) {
 	_, err = format.Decode(fake.NewBadContext(), []byte(`{}`))
 	require.EqualError(t, err, "failed to unmarshal: fake error")
 
-	badCtx := serde.WithFactory(ctx, types.SignatureKey{}, fake.NewBadSignatureFactory())
+	badCtx := serde.WithFactory(ctx, types.AggregateKey{}, fake.NewBadSignatureFactory())
 	_, err = format.Decode(badCtx, []byte(`{}`))
 	require.EqualError(t, err, "failed to decode prepare: factory failed: fake error")
 
-	badCtx = serde.WithFactory(ctx, types.SignatureKey{}, fake.NewBadSignatureFactoryWithDelay(1))
+	badCtx = serde.WithFactory(ctx, types.AggregateKey{}, fake.NewBadSignatureFactoryWithDelay(1))
 	_, err = format.Decode(badCtx, []byte(`{}`))
 	require.EqualError(t, err, "failed to decode commit: factory failed: fake error")
 

--- a/core/ordering/cosipbft/json/mod.go
+++ b/core/ordering/cosipbft/json/mod.go
@@ -310,7 +310,7 @@ func (f msgFormat) Encode(ctx serde.Context, msg serde.Message) ([]byte, error) 
 	case types.ViewMessage:
 		vm, err := encodeView(in, ctx)
 		if err != nil {
-			return nil, err
+			return nil, xerrors.Errorf("view: %v", err)
 		}
 
 		m = MessageJSON{View: vm}

--- a/core/ordering/cosipbft/json/mod_test.go
+++ b/core/ordering/cosipbft/json/mod_test.go
@@ -185,7 +185,7 @@ func TestMsgFormat_Encode(t *testing.T) {
 	require.Regexp(t, `{"View":{"Leader":5,"ID":"[^"]+","Signature":{}}}`, string(data))
 
 	_, err = format.Encode(ctx, types.NewViewMessage(types.Digest{}, 0, fake.NewBadSignature()))
-	require.EqualError(t, err, "failed to serialize signature: fake error")
+	require.EqualError(t, err, "view: failed to serialize signature: fake error")
 
 	_, err = format.Encode(fake.NewBadContext(), types.NewViewMessage(types.Digest{}, 0, fake.Signature{}))
 	require.EqualError(t, err, "failed to marshal: fake error")

--- a/core/ordering/cosipbft/json/mod_test.go
+++ b/core/ordering/cosipbft/json/mod_test.go
@@ -158,6 +158,11 @@ func TestMsgFormat_Encode(t *testing.T) {
 	_, err = format.Encode(ctx, types.NewBlockMessage(block, views))
 	require.EqualError(t, err, "view: failed to serialize signature: fake error")
 
+	delete(views, fake.NewAddress(0))
+	views[fake.NewBadAddress()] = types.NewViewMessage(types.Digest{}, 0, fake.Signature{})
+	_, err = format.Encode(ctx, types.NewBlockMessage(block, views))
+	require.EqualError(t, err, "failed to serialize address: fake error")
+
 	_, err = format.Encode(fake.NewBadContext(), types.NewBlockMessage(block, nil))
 	require.EqualError(t, err, "block: encoding failed: fake error")
 
@@ -228,6 +233,10 @@ func TestMsgFormat_Decode(t *testing.T) {
 	badCtx = serde.WithFactory(ctx, types.BlockKey{}, fake.MessageFactory{})
 	_, err = format.Decode(badCtx, []byte(`{"Block":{}}`))
 	require.EqualError(t, err, "invalid block 'fake.Message'")
+
+	badCtx = serde.WithFactory(ctx, types.AddressKey{}, nil)
+	_, err = format.Decode(badCtx, []byte(`{"Block":{"Views":{"":{}}}}`))
+	require.EqualError(t, err, "invalid address factory '<nil>'")
 
 	badCtx = serde.WithFactory(ctx, types.SignatureKey{}, nil)
 	_, err = format.Decode(badCtx, []byte(`{"Block":{"Views":{"":{}}}}`))

--- a/core/ordering/cosipbft/json/mod_test.go
+++ b/core/ordering/cosipbft/json/mod_test.go
@@ -8,6 +8,7 @@ import (
 	"go.dedis.ch/dela/core/ordering/cosipbft/authority"
 	"go.dedis.ch/dela/core/ordering/cosipbft/types"
 	"go.dedis.ch/dela/internal/testing/fake"
+	"go.dedis.ch/dela/mino"
 	"go.dedis.ch/dela/serde"
 	"golang.org/x/xerrors"
 )
@@ -145,12 +146,20 @@ func TestMsgFormat_Encode(t *testing.T) {
 	_, err = format.Encode(fake.NewBadContext(), types.NewGenesisMessage(genesis))
 	require.EqualError(t, err, "failed to serialize genesis: encoding failed: fake error")
 
-	data, err = format.Encode(ctx, types.NewBlockMessage(block))
+	views := map[mino.Address]types.ViewMessage{
+		fake.NewAddress(0): types.NewViewMessage(types.Digest{1}, 5, fake.Signature{}),
+	}
+	data, err = format.Encode(ctx, types.NewBlockMessage(block, views))
 	require.NoError(t, err)
-	require.Equal(t, `{"Block":{"Block":{}}}`, string(data))
+	require.Regexp(t,
+		`{"Block":{"Block":{},"Views":{"[^"]+":{"Leader":5,"ID":"[^"]+","Signature":{}}}}}`, string(data))
 
-	_, err = format.Encode(fake.NewBadContext(), types.NewBlockMessage(block))
-	require.EqualError(t, err, "failed to serialize block: encoding failed: fake error")
+	views[fake.NewAddress(0)] = types.NewViewMessage(types.Digest{}, 0, fake.NewBadSignature())
+	_, err = format.Encode(ctx, types.NewBlockMessage(block, views))
+	require.EqualError(t, err, "view: failed to serialize signature: fake error")
+
+	_, err = format.Encode(fake.NewBadContext(), types.NewBlockMessage(block, nil))
+	require.EqualError(t, err, "block: encoding failed: fake error")
 
 	data, err = format.Encode(ctx, types.NewCommit(types.Digest{}, fake.Signature{}))
 	require.NoError(t, err)
@@ -185,6 +194,7 @@ func TestMsgFormat_Decode(t *testing.T) {
 	ctx = serde.WithFactory(ctx, types.BlockKey{}, types.BlockFactory{})
 	ctx = serde.WithFactory(ctx, types.AggregateKey{}, fake.SignatureFactory{})
 	ctx = serde.WithFactory(ctx, types.SignatureKey{}, fake.SignatureFactory{})
+	ctx = serde.WithFactory(ctx, types.AddressKey{}, fake.AddressFactory{})
 
 	msg, err := format.Decode(ctx, []byte(`{"Genesis":{}}`))
 	require.NoError(t, err)
@@ -202,9 +212,10 @@ func TestMsgFormat_Decode(t *testing.T) {
 	_, err = format.Decode(badCtx, []byte(`{"Genesis":{}}`))
 	require.EqualError(t, err, "invalid genesis 'fake.Message'")
 
-	msg, err = format.Decode(ctx, []byte(`{"Block":{}}`))
+	msg, err = format.Decode(ctx, []byte(`{"Block":{"Views":{"":{}}}}`))
 	require.NoError(t, err)
 	require.IsType(t, types.BlockMessage{}, msg)
+	require.Len(t, msg.(types.BlockMessage).GetViews(), 1)
 
 	badCtx = serde.WithFactory(ctx, types.BlockKey{}, nil)
 	_, err = format.Decode(badCtx, []byte(`{"Block":{}}`))
@@ -217,6 +228,10 @@ func TestMsgFormat_Decode(t *testing.T) {
 	badCtx = serde.WithFactory(ctx, types.BlockKey{}, fake.MessageFactory{})
 	_, err = format.Decode(badCtx, []byte(`{"Block":{}}`))
 	require.EqualError(t, err, "invalid block 'fake.Message'")
+
+	badCtx = serde.WithFactory(ctx, types.SignatureKey{}, nil)
+	_, err = format.Decode(badCtx, []byte(`{"Block":{"Views":{"":{}}}}`))
+	require.EqualError(t, err, "view: signature: invalid signature factory '<nil>'")
 
 	msg, err = format.Decode(ctx, []byte(`{"Commit":{}}`))
 	require.NoError(t, err)

--- a/core/ordering/cosipbft/mod.go
+++ b/core/ordering/cosipbft/mod.go
@@ -176,7 +176,11 @@ func NewService(param ServiceParam, opts ...ServiceOption) (*Service, error) {
 	go func() {
 		err := s.main()
 		if err != nil {
-			s.logger.Err(err).Msg("main loop failed")
+			select {
+			case <-s.closing:
+			default:
+				s.logger.Err(err).Msg("main loop failed")
+			}
 		}
 
 		close(s.closed)

--- a/core/ordering/cosipbft/mod.go
+++ b/core/ordering/cosipbft/mod.go
@@ -107,6 +107,7 @@ func NewService(param ServiceParam, opts ...ServiceOption) (*Service, error) {
 
 	pcparam := pbft.StateMachineParam{
 		Validation:      param.Validation,
+		Signer:          param.Cosi.GetSigner(),
 		VerifierFactory: param.Cosi.GetVerifierFactory(),
 		Blocks:          tmpl.blocks,
 		Genesis:         tmpl.genesis,
@@ -404,7 +405,9 @@ func (s *Service) doRound(ctx context.Context) error {
 				return xerrors.Errorf("pbft expire failed: %v", err)
 			}
 
-			resps, err := s.rpc.Call(ctx, types.NewViewMessage(view.ID, view.Leader), roster)
+			viewMsg := types.NewViewMessage(view.GetID(), view.GetLeader(), view.GetSignature())
+
+			resps, err := s.rpc.Call(ctx, viewMsg, roster)
 			if err != nil {
 				cancel()
 				return xerrors.Errorf("rpc failed: %v", err)

--- a/core/ordering/cosipbft/mod_test.go
+++ b/core/ordering/cosipbft/mod_test.go
@@ -566,6 +566,10 @@ type badCosi struct {
 	cosi.CollectiveSigning
 }
 
+func (c badCosi) GetSigner() crypto.Signer {
+	return fake.NewBadSigner()
+}
+
 func (c badCosi) GetPublicKeyFactory() crypto.PublicKeyFactory {
 	return fake.NewPublicKeyFactory(fake.PublicKey{})
 }

--- a/core/ordering/cosipbft/mod_test.go
+++ b/core/ordering/cosipbft/mod_test.go
@@ -126,11 +126,16 @@ func TestService_New(t *testing.T) {
 		Cosi:       flatcosi.NewFlat(fake.Mino{}, fake.NewAggregateSigner()),
 		Tree:       fakeTree{},
 		Validation: simple.NewService(nil, nil),
+		Pool:       badPool{},
 	}
 
 	srvc, err := NewService(param, WithHashFactory(fake.NewHashFactory(&fake.Hash{})))
 	require.NoError(t, err)
 	require.NotNil(t, srvc)
+
+	srvc.logger = zerolog.New(ioutil.Discard)
+	close(srvc.started)
+	<-srvc.closed
 
 	param.Mino = fake.NewBadMino()
 	_, err = NewService(param)

--- a/core/ordering/cosipbft/pbft/mod.go
+++ b/core/ordering/cosipbft/pbft/mod.go
@@ -320,7 +320,7 @@ func (m *pbftsm) Accept(view View) error {
 
 // AcceptAll implements pbft.StateMachine. It accepts a list of views which
 // allows a node falling behind to catch up. The list must contain enough views
-// reach the threshold otherwise it will be ignored.
+// to reach the threshold, otherwise it will be ignored.
 func (m *pbftsm) AcceptAll(views []View) error {
 	m.Lock()
 	defer m.Unlock()
@@ -331,7 +331,8 @@ func (m *pbftsm) AcceptAll(views []View) error {
 	}
 
 	if len(views) <= m.round.threshold {
-		return xerrors.New("not enough views")
+		return xerrors.Errorf("not enough views: %d <= %d",
+			len(views), m.round.threshold)
 	}
 
 	if views[0].leader == m.round.leader {

--- a/core/ordering/cosipbft/pbft/mod_test.go
+++ b/core/ordering/cosipbft/pbft/mod_test.go
@@ -371,7 +371,7 @@ func TestStateMachine_AcceptAll(t *testing.T) {
 
 	// Only accept if there are enough views.
 	err = sm.AcceptAll([]View{})
-	require.EqualError(t, err, "not enough views")
+	require.EqualError(t, err, "not enough views: 0 <= 0")
 
 	err = sm.AcceptAll([]View{{from: fake.NewAddress(4), leader: 6}})
 	require.EqualError(t, err, "invalid view: unknown peer: fake.Address[4]")

--- a/core/ordering/cosipbft/pbft/view.go
+++ b/core/ordering/cosipbft/pbft/view.go
@@ -84,7 +84,7 @@ func (v View) Verify(pubkey crypto.PublicKey) error {
 }
 
 func (v View) bytes() []byte {
-	buffer := make([]byte, 8)
+	buffer := make([]byte, 2)
 	binary.LittleEndian.PutUint16(buffer, v.leader)
 
 	return append(buffer, v.id.Bytes()...)

--- a/core/ordering/cosipbft/pbft/view.go
+++ b/core/ordering/cosipbft/pbft/view.go
@@ -1,0 +1,91 @@
+package pbft
+
+import (
+	"encoding/binary"
+
+	"go.dedis.ch/dela/core/ordering/cosipbft/types"
+	"go.dedis.ch/dela/crypto"
+	"go.dedis.ch/dela/mino"
+	"golang.org/x/xerrors"
+)
+
+// View is the view change request sent to other participants.
+type View struct {
+	from      mino.Address
+	id        types.Digest
+	leader    uint16
+	signature crypto.Signature
+}
+
+// ViewParam contains the parameters to create a view.
+type ViewParam struct {
+	From   mino.Address
+	ID     types.Digest
+	Leader uint16
+}
+
+// NewView creates a new view.
+func NewView(param ViewParam, sig crypto.Signature) View {
+	return View{
+		from:      param.From,
+		id:        param.ID,
+		leader:    param.Leader,
+		signature: sig,
+	}
+}
+
+// NewViewAndSign creates a new view and uses the signer to make the signature
+// that will be verified by other participants.
+func NewViewAndSign(param ViewParam, signer crypto.Signer) (View, error) {
+	view := View{
+		from:   param.From,
+		id:     param.ID,
+		leader: param.Leader,
+	}
+
+	sig, err := signer.Sign(view.bytes())
+	if err != nil {
+		return view, xerrors.Errorf("signer: %v", err)
+	}
+
+	view.signature = sig
+
+	return view, nil
+}
+
+// GetFrom returns the address the view is coming from.
+func (v View) GetFrom() mino.Address {
+	return v.from
+}
+
+// GetID returns the block digest the view is targeting.
+func (v View) GetID() types.Digest {
+	return v.id
+}
+
+// GetLeader returns the index of the leader proposed by the view.
+func (v View) GetLeader() uint16 {
+	return v.leader
+}
+
+// GetSignature returns the signature of the view.
+func (v View) GetSignature() crypto.Signature {
+	return v.signature
+}
+
+// Verify takes the public key to verify the signature of the view.
+func (v View) Verify(pubkey crypto.PublicKey) error {
+	err := pubkey.Verify(v.bytes(), v.signature)
+	if err != nil {
+		return xerrors.Errorf("verify: %v", err)
+	}
+
+	return nil
+}
+
+func (v View) bytes() []byte {
+	buffer := make([]byte, 8)
+	binary.LittleEndian.PutUint16(buffer, v.leader)
+
+	return append(buffer, v.id.Bytes()...)
+}

--- a/core/ordering/cosipbft/pbft/view_test.go
+++ b/core/ordering/cosipbft/pbft/view_test.go
@@ -1,0 +1,45 @@
+package pbft
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.dedis.ch/dela/core/ordering/cosipbft/types"
+	"go.dedis.ch/dela/crypto/bls"
+	"go.dedis.ch/dela/internal/testing/fake"
+)
+
+func TestView_Getters(t *testing.T) {
+	param := ViewParam{
+		From:   fake.NewAddress(0),
+		ID:     types.Digest{1},
+		Leader: 5,
+	}
+
+	view := NewView(param, fake.Signature{})
+
+	require.Equal(t, fake.NewAddress(0), view.GetFrom())
+	require.Equal(t, types.Digest{1}, view.GetID())
+	require.Equal(t, uint16(5), view.GetLeader())
+	require.Equal(t, fake.Signature{}, view.GetSignature())
+}
+
+func TestView_Verify(t *testing.T) {
+	param := ViewParam{
+		From:   fake.NewAddress(0),
+		ID:     types.Digest{2},
+		Leader: 3,
+	}
+
+	signer := bls.NewSigner()
+
+	view, err := NewViewAndSign(param, signer)
+	require.NoError(t, err)
+	require.NoError(t, view.Verify(signer.GetPublicKey()))
+
+	_, err = NewViewAndSign(param, fake.NewBadSigner())
+	require.EqualError(t, err, "signer: fake error")
+
+	err = view.Verify(fake.NewBadPublicKey())
+	require.EqualError(t, err, "verify: fake error")
+}

--- a/core/ordering/cosipbft/proc.go
+++ b/core/ordering/cosipbft/proc.go
@@ -116,13 +116,16 @@ func (h *processor) Process(req mino.Request) (serde.Message, error) {
 			return nil, xerrors.Errorf("pbftsm finalized failed: %v", err)
 		}
 	case types.ViewMessage:
-		view := pbft.View{
+		param := pbft.ViewParam{
 			From:   req.Address,
 			ID:     msg.GetID(),
 			Leader: msg.GetLeader(),
 		}
 
-		h.pbftsm.Accept(view)
+		err := h.pbftsm.Accept(pbft.NewView(param, msg.GetSignature()))
+		if err != nil {
+			h.logger.Warn().Err(err).Msg("view message refused")
+		}
 	default:
 		return nil, xerrors.Errorf("unsupported message of type '%T'", req.Message)
 	}

--- a/core/ordering/cosipbft/proc_test.go
+++ b/core/ordering/cosipbft/proc_test.go
@@ -137,7 +137,9 @@ func TestProcessor_ViewMessage_Process(t *testing.T) {
 	proc := newProcessor()
 	proc.pbftsm = fakeSM{}
 
-	req := mino.Request{Message: types.NewViewMessage(types.Digest{}, 0)}
+	req := mino.Request{
+		Message: types.NewViewMessage(types.Digest{}, 0, fake.Signature{}),
+	}
 
 	resp, err := proc.Process(req)
 	require.NoError(t, err)
@@ -204,7 +206,9 @@ func (sm fakeSM) Expire(mino.Address) (pbft.View, error) {
 	return pbft.View{}, sm.err
 }
 
-func (sm fakeSM) Accept(pbft.View) {}
+func (sm fakeSM) Accept(pbft.View) error {
+	return nil
+}
 
 func (sm fakeSM) Watch(context.Context) <-chan pbft.State {
 	return sm.ch

--- a/core/ordering/cosipbft/proc_test.go
+++ b/core/ordering/cosipbft/proc_test.go
@@ -32,7 +32,7 @@ func TestProcessor_BlockMessage_Invoke(t *testing.T) {
 		id:    expected,
 	}
 
-	msg := types.NewBlockMessage(types.Block{})
+	msg := types.NewBlockMessage(types.Block{}, nil)
 
 	id, err := proc.Invoke(fake.NewAddress(0), msg)
 	require.NoError(t, err)
@@ -184,6 +184,10 @@ func (sm fakeSM) GetState() pbft.State {
 
 func (sm fakeSM) GetLeader() (mino.Address, error) {
 	return fake.NewAddress(0), sm.errLeader
+}
+
+func (sm fakeSM) GetViews() map[mino.Address]pbft.View {
+	return nil
 }
 
 func (sm fakeSM) PrePrepare(authority.Authority) error {

--- a/core/ordering/cosipbft/types/chain.go
+++ b/core/ordering/cosipbft/types/chain.go
@@ -240,7 +240,7 @@ func (fac linkFac) Deserialize(ctx serde.Context, data []byte) (serde.Message, e
 	format := linkFormats.Get(ctx.GetFormat())
 
 	ctx = serde.WithFactory(ctx, BlockKey{}, fac.blockFac)
-	ctx = serde.WithFactory(ctx, SignatureKey{}, fac.sigFac)
+	ctx = serde.WithFactory(ctx, AggregateKey{}, fac.sigFac)
 	ctx = serde.WithFactory(ctx, ChangeSetKey{}, fac.csFac)
 
 	msg, err := format.Decode(ctx, data)

--- a/core/ordering/cosipbft/types/messages_test.go
+++ b/core/ordering/cosipbft/types/messages_test.go
@@ -96,19 +96,25 @@ func TestDoneMessage_Serialize(t *testing.T) {
 }
 
 func TestViewMessage_GetID(t *testing.T) {
-	msg := NewViewMessage(Digest{1}, 0)
+	msg := NewViewMessage(Digest{1}, 0, nil)
 
 	require.Equal(t, Digest{1}, msg.GetID())
 }
 
 func TestViewMessage_GetLeader(t *testing.T) {
-	msg := NewViewMessage(Digest{}, 2)
+	msg := NewViewMessage(Digest{}, 2, nil)
 
-	require.Equal(t, 2, msg.GetLeader())
+	require.Equal(t, uint16(2), msg.GetLeader())
+}
+
+func TestViewMessage_GetSignature(t *testing.T) {
+	msg := NewViewMessage(Digest{}, 0, fake.Signature{})
+
+	require.Equal(t, fake.Signature{}, msg.GetSignature())
 }
 
 func TestViewMessage_Serialize(t *testing.T) {
-	msg := NewViewMessage(Digest{}, 3)
+	msg := NewViewMessage(Digest{}, 3, fake.Signature{})
 
 	data, err := msg.Serialize(fake.NewContext())
 	require.NoError(t, err)


### PR DESCRIPTION
This adds a signature to view messages so that it can be verified that a node asked for a view change.

Also: add view messages when sending a proposed block if the leader comes from a view change so that nodes can catch up if necessary.