### PR TITLE
Fix cosipbft issue

### DIFF
--- a/core/ordering/cosipbft/blockstore/mod.go
+++ b/core/ordering/cosipbft/blockstore/mod.go
@@ -3,6 +3,7 @@ package blockstore
 import (
 	"context"
 	"errors"
+	"sync"
 
 	"go.dedis.ch/dela/core/ordering/cosipbft/types"
 	"go.dedis.ch/dela/core/store"
@@ -18,6 +19,10 @@ type TreeCache interface {
 	Get() hashtree.Tree
 
 	Set(hashtree.Tree)
+
+	// SetAndLock sets the tree and acquires the cache lock until the wait group
+	// is done which allows an external caller to delay the release of the lock.
+	SetAndLock(hashtree.Tree, *sync.WaitGroup)
 }
 
 // GenesisStore is the interface to store and get the genesis block. It is left

--- a/core/ordering/cosipbft/blockstore/tree.go
+++ b/core/ordering/cosipbft/blockstore/tree.go
@@ -1,7 +1,7 @@
 package blockstore
 
 import (
-	"sync/atomic"
+	"sync"
 
 	"go.dedis.ch/dela/core/store/hashtree"
 )
@@ -10,27 +10,44 @@ import (
 //
 // - implements blockstore.TreeCache
 type treeCache struct {
-	tree atomic.Value
+	sync.Mutex
+	tree hashtree.Tree
 }
 
 // NewTreeCache creates a new cache with the given tree as the first value.
 func NewTreeCache(tree hashtree.Tree) TreeCache {
-	var value atomic.Value
-	value.Store(tree)
-
 	return &treeCache{
-		tree: value,
+		tree: tree,
 	}
 }
 
 // Get implements blockstore.TreeCache. It returns the current value of the
 // cache.
 func (c *treeCache) Get() hashtree.Tree {
-	return c.tree.Load().(hashtree.Tree)
+	c.Lock()
+	defer c.Unlock()
+
+	return c.tree
 }
 
 // Set implements blockstore.TreeCache. It stores the new tree as the cache
 // value but panic if it is nil.
 func (c *treeCache) Set(tree hashtree.Tree) {
-	c.tree.Store(tree)
+	c.Lock()
+	c.tree = tree
+	c.Unlock()
+}
+
+// SetAndLock implements blockstore.TreeCache. It sets the tree and acquires the
+// cache lock until the wait group is done which allows an external caller to
+// delay the release of the lock.
+func (c *treeCache) SetAndLock(tree hashtree.Tree, lock *sync.WaitGroup) {
+	c.Lock()
+	c.tree = tree
+
+	// This allows an external call to hold the cache until some event are
+	// fulfilled.
+	lock.Wait()
+
+	c.Unlock()
 }

--- a/core/ordering/cosipbft/blockstore/tree.go
+++ b/core/ordering/cosipbft/blockstore/tree.go
@@ -45,9 +45,11 @@ func (c *treeCache) SetAndLock(tree hashtree.Tree, lock *sync.WaitGroup) {
 	c.Lock()
 	c.tree = tree
 
-	// This allows an external call to hold the cache until some event are
-	// fulfilled.
-	lock.Wait()
+	go func() {
+		// This allows an external call to hold the cache until some event are
+		// fulfilled.
+		lock.Wait()
 
-	c.Unlock()
+		c.Unlock()
+	}()
 }

--- a/core/ordering/cosipbft/blockstore/tree_test.go
+++ b/core/ordering/cosipbft/blockstore/tree_test.go
@@ -28,7 +28,7 @@ func TestTreeCache_SetAndLock(t *testing.T) {
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 
-	go cache.SetAndLock(fakeTree{}, &wg)
+	cache.SetAndLock(fakeTree{}, &wg)
 
 	ch := make(chan struct{})
 	go func() {

--- a/core/ordering/cosipbft/blockstore/tree_test.go
+++ b/core/ordering/cosipbft/blockstore/tree_test.go
@@ -1,7 +1,9 @@
 package blockstore
 
 import (
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.dedis.ch/dela/core/store/hashtree"
@@ -18,6 +20,37 @@ func TestTreeCache_Set(t *testing.T) {
 
 	cache.Set(fakeTree{value: 1})
 	require.Equal(t, fakeTree{value: 1}, cache.Get())
+}
+
+func TestTreeCache_SetAndLock(t *testing.T) {
+	cache := NewTreeCache(fakeTree{})
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
+	go cache.SetAndLock(fakeTree{}, &wg)
+
+	ch := make(chan struct{})
+	go func() {
+		cache.Get()
+		close(ch)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	select {
+	case <-ch:
+		t.Fatal("get should be locked")
+	default:
+	}
+
+	wg.Done()
+
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatal("get should be released")
+	}
 }
 
 // -----------------------------------------------------------------------------

--- a/core/ordering/cosipbft/mod_test.go
+++ b/core/ordering/cosipbft/mod_test.go
@@ -96,7 +96,8 @@ func TestService_Scenario_ViewChange(t *testing.T) {
 	defer clean()
 
 	for _, node := range nodes {
-		node.service.timeout = 200 * time.Millisecond
+		node.service.timeoutRound = 200 * time.Millisecond
+		node.service.timeoutViewchange = 10 * time.Second
 	}
 
 	// Simulate an issue with the leader transaction pool so that it does not
@@ -220,11 +221,11 @@ func TestService_DoRound(t *testing.T) {
 	ch := make(chan pbft.State)
 
 	srvc := &Service{
-		processor: newProcessor(),
-		me:        fake.NewAddress(1),
-		rpc:       rpc,
-		timeout:   time.Millisecond,
-		closing:   make(chan struct{}),
+		processor:    newProcessor(),
+		me:           fake.NewAddress(1),
+		rpc:          rpc,
+		timeoutRound: time.Millisecond,
+		closing:      make(chan struct{}),
 	}
 	srvc.blocks = blockstore.NewInMemory()
 	srvc.sync = fakeSync{}

--- a/core/ordering/cosipbft/pbft/mod.go
+++ b/core/ordering/cosipbft/pbft/mod.go
@@ -600,7 +600,7 @@ func (m *pbftsm) verifyFinalize(r *round, sig crypto.Signature, ro authority.Aut
 		txn.OnCommit(func() {
 			// The cache is updated only after both are committed with the tree
 			// using the database as the transaction is done.
-			go m.tree.SetAndLock(r.tree, &wg)
+			m.tree.SetAndLock(r.tree, &wg)
 		})
 
 		// 2. Persist the block and its forward link.


### PR DESCRIPTION
This fixes an issue with timeouts in the test and it also fixes a rare issue where the proof can be unsync between the tree and the latest block.