### PR TITLE
Disable logging and allow to set the level with an env variable

### DIFF
--- a/core/ordering/cosipbft/mod_test.go
+++ b/core/ordering/cosipbft/mod_test.go
@@ -96,7 +96,8 @@ func TestService_Scenario_ViewChange(t *testing.T) {
 	defer clean()
 
 	for _, node := range nodes {
-		node.service.timeoutRound = 200 * time.Millisecond
+		// Must be high enough for slow machines.
+		node.service.timeoutRound = 500 * time.Millisecond
 		node.service.timeoutViewchange = 10 * time.Second
 	}
 
@@ -556,9 +557,6 @@ func makeAuthority(t *testing.T, n int) ([]testNode, authority.Authority, func()
 
 		srv, err := NewService(param)
 		require.NoError(t, err)
-
-		// Disable logs.
-		srv.logger = srv.logger.Level(zerolog.ErrorLevel)
 
 		nodes[i] = testNode{
 			service: srv,

--- a/mod.go
+++ b/mod.go
@@ -7,13 +7,44 @@ import (
 	"github.com/rs/zerolog"
 )
 
+// EnvLogLevel is the name of the environment variable to change the logging
+// level.
+const EnvLogLevel = "LLVL"
+
+const defaultLevel = zerolog.NoLevel
+
+func init() {
+	lvl := os.Getenv(EnvLogLevel)
+
+	var level zerolog.Level
+
+	switch lvl {
+	case "error":
+		level = zerolog.ErrorLevel
+	case "warn":
+		level = zerolog.WarnLevel
+	case "info":
+		level = zerolog.InfoLevel
+	case "debug":
+		level = zerolog.DebugLevel
+	case "trace":
+		level = zerolog.TraceLevel
+	case "":
+		level = defaultLevel
+	default:
+		level = zerolog.TraceLevel
+	}
+
+	Logger = Logger.Level(level)
+}
+
 var logout = zerolog.ConsoleWriter{
 	Out:        os.Stdout,
 	TimeFormat: time.RFC3339,
 }
 
-// Logger is a globally available logger instance.
-var Logger = zerolog.New(logout).
+// Logger is a globally available logger instance. By default, it only prints
+// error level messages but it can be changed through a environment variable.
+var Logger = zerolog.New(logout).Level(defaultLevel).
 	With().Timestamp().Logger().
-	With().Caller().Logger().
-	Level(zerolog.DebugLevel)
+	With().Caller().Logger()


### PR DESCRIPTION
Also: increase round timeout because of slow machines.