### PR TITLE
Core: use a thresholded collective signing

### DIFF
--- a/core/ordering/cosipbft/blocksync/default.go
+++ b/core/ordering/cosipbft/blocksync/default.go
@@ -104,7 +104,7 @@ func (s defaultSync) Sync(ctx context.Context, players mino.Players, cfg Config)
 	errs := sender.Send(types.NewSyncMessage(chain), iter2arr(players.AddressIterator())...)
 	for err := range errs {
 		if err != nil {
-			return xerrors.Errorf("announcement failed: %v", err)
+			s.logger.Warn().Err(err).Msg("announcement failed")
 		}
 	}
 

--- a/core/ordering/cosipbft/controller/mod.go
+++ b/core/ordering/cosipbft/controller/mod.go
@@ -19,7 +19,7 @@ import (
 	poolimpl "go.dedis.ch/dela/core/txn/pool/gossip"
 	"go.dedis.ch/dela/core/txn/signed"
 	"go.dedis.ch/dela/core/validation/simple"
-	"go.dedis.ch/dela/cosi/flatcosi"
+	"go.dedis.ch/dela/cosi/threshold"
 	"go.dedis.ch/dela/crypto"
 	"go.dedis.ch/dela/crypto/bls"
 	"go.dedis.ch/dela/mino"
@@ -92,7 +92,9 @@ func (minimal) Inject(flags cli.Flags, inj node.Injector) error {
 		return xerrors.Errorf("signer: %v", err)
 	}
 
-	cosi := flatcosi.NewFlat(m, signer)
+	cosi := threshold.NewCoSi(m, signer)
+	cosi.SetThreshold(threshold.ByzantineThreshold)
+
 	exec := baremetal.NewExecution()
 	access := darc.NewService(json.NewContext())
 

--- a/core/ordering/cosipbft/mod.go
+++ b/core/ordering/cosipbft/mod.go
@@ -22,6 +22,7 @@ import (
 	"go.dedis.ch/dela/core/txn/pool"
 	"go.dedis.ch/dela/core/validation"
 	"go.dedis.ch/dela/cosi"
+	"go.dedis.ch/dela/cosi/threshold"
 	"go.dedis.ch/dela/crypto"
 	"go.dedis.ch/dela/mino"
 	"golang.org/x/xerrors"
@@ -486,8 +487,7 @@ func (s *Service) doRound(ctx context.Context) error {
 
 	// Send a synchronization to the roster so that they can learn about the
 	// latest block of the chain.
-	// TODO: get pbft threshold
-	err = s.sync.Sync(ctx, roster, blocksync.Config{MinHard: roster.Len()})
+	err = s.sync.Sync(ctx, roster, blocksync.Config{MinHard: threshold.ByzantineThreshold(roster.Len())})
 	if err != nil {
 		return xerrors.Errorf("sync failed: %v", err)
 	}

--- a/core/ordering/cosipbft/mod_test.go
+++ b/core/ordering/cosipbft/mod_test.go
@@ -31,6 +31,7 @@ import (
 	"go.dedis.ch/dela/core/validation/simple"
 	"go.dedis.ch/dela/cosi"
 	"go.dedis.ch/dela/cosi/flatcosi"
+	"go.dedis.ch/dela/cosi/threshold"
 	"go.dedis.ch/dela/crypto"
 	"go.dedis.ch/dela/crypto/bls"
 	"go.dedis.ch/dela/internal/testing/fake"
@@ -532,7 +533,8 @@ func makeAuthority(t *testing.T, n int) ([]testNode, authority.Authority, func()
 		signer := bls.NewSigner()
 		pubkeys[i] = signer.GetPublicKey()
 
-		c := flatcosi.NewFlat(m, signer)
+		c := threshold.NewCoSi(m, signer)
+		c.SetThreshold(threshold.ByzantineThreshold)
 
 		dir, err := ioutil.TempDir(os.TempDir(), "cosipbft")
 		require.NoError(t, err)

--- a/cosi/flatcosi/mod.go
+++ b/cosi/flatcosi/mod.go
@@ -17,7 +17,10 @@ const (
 )
 
 // Flat is an implementation of the collective signing interface by
-// using BLS signatures.
+// using BLS signatures. It ignores the threshold and always requests a
+// signature from every participant.
+//
+// - implements cosi.CollectiveSigning
 type Flat struct {
 	mino   mino.Mino
 	signer crypto.AggregateSigner
@@ -37,23 +40,31 @@ func (flat *Flat) GetSigner() crypto.Signer {
 	return flat.signer
 }
 
-// GetPublicKeyFactory returns the public key factory.
+// GetPublicKeyFactory implements cosi.CollectiveSigning. It returns the public
+// key factory.
 func (flat *Flat) GetPublicKeyFactory() crypto.PublicKeyFactory {
 	return flat.signer.GetPublicKeyFactory()
 }
 
-// GetSignatureFactory returns the signature factory.
+// GetSignatureFactory implements cosi.CollectiveSigning. It returns the
+// signature factory.
 func (flat *Flat) GetSignatureFactory() crypto.SignatureFactory {
 	return flat.signer.GetSignatureFactory()
 }
 
-// GetVerifierFactory returns the verifier factory.
+// GetVerifierFactory implements cosi.CollectiveSigning. It returns the verifier
+// factory.
 func (flat *Flat) GetVerifierFactory() crypto.VerifierFactory {
 	return flat.signer.GetVerifierFactory()
 }
 
-// Listen creates an actor that starts an RPC called cosi and respond to signing
-// requests. The actor can also be used to sign a message.
+// SetThreshold implements cosi.CollectiveSigning. It ignores the new threshold
+// as this implementation only accepts full participation.
+func (flat *Flat) SetThreshold(fn cosi.Threshold) {}
+
+// Listen implements cosi.CollectiveSigning. It creates an actor that starts an
+// RPC called cosi and respond to signing requests. The actor can also be used
+// to sign a message.
 func (flat *Flat) Listen(r cosi.Reactor) (cosi.Actor, error) {
 	actor := flatActor{
 		logger:  dela.Logger,
@@ -82,7 +93,7 @@ type flatActor struct {
 	reactor cosi.Reactor
 }
 
-// Sign returns the collective signature of the block.
+// Sign implements cosi.Actor. It returns the collective signature of the block.
 func (a flatActor) Sign(ctx context.Context, msg serde.Message,
 	ca crypto.CollectiveAuthority) (crypto.Signature, error) {
 

--- a/cosi/mod.go
+++ b/cosi/mod.go
@@ -26,6 +26,9 @@ type Actor interface {
 		ca crypto.CollectiveAuthority) (crypto.Signature, error)
 }
 
+// Threshold is a function that returns the threshold to reach for a given n.
+type Threshold func(int) int
+
 // CollectiveSigning is the interface that provides the primitives to sign a
 // message by members of a network.
 type CollectiveSigning interface {
@@ -43,6 +46,9 @@ type CollectiveSigning interface {
 	// GetVerifierFactory returns a factory that can create a verifier to check
 	// the validity of a signature.
 	GetVerifierFactory() crypto.VerifierFactory
+
+	// SetThreshold updates the threshold required by a collective signature.
+	SetThreshold(Threshold)
 
 	// Listen starts the collective signing so that it will answer to requests.
 	Listen(Reactor) (Actor, error)

--- a/cosi/threshold/actor.go
+++ b/cosi/threshold/actor.go
@@ -3,8 +3,10 @@ package threshold
 import (
 	"context"
 
+	"github.com/rs/zerolog"
 	"go.dedis.ch/dela"
 	"go.dedis.ch/dela/cosi"
+	"go.dedis.ch/dela/cosi/threshold/types"
 	"go.dedis.ch/dela/crypto"
 	"go.dedis.ch/dela/mino"
 	"go.dedis.ch/dela/serde"
@@ -17,6 +19,8 @@ import (
 // - implements cosi.Actor
 type thresholdActor struct {
 	*CoSi
+
+	logger  zerolog.Logger
 	me      mino.Address
 	rpc     mino.RPC
 	reactor cosi.Reactor
@@ -42,7 +46,7 @@ func (a thresholdActor) Sign(ctx context.Context, msg serde.Message,
 
 	// The aggregated signature needs to include at least a threshold number of
 	// signatures.
-	thres := a.Threshold(ca.Len())
+	thres := a.threshold.Load().(cosi.Threshold)(ca.Len())
 
 	req := cosi.SignatureRequest{
 		Value: msg,
@@ -55,7 +59,7 @@ func (a thresholdActor) Sign(ctx context.Context, msg serde.Message,
 	go a.waitCtx(innerCtx, ctx, cancel)
 
 	count := 0
-	signature := &Signature{}
+	signature := new(types.Signature)
 	for count < thres {
 		addr, resp, err := rcvr.Recv(innerCtx)
 		if err != nil {
@@ -66,7 +70,7 @@ func (a thresholdActor) Sign(ctx context.Context, msg serde.Message,
 		if index >= 0 {
 			err = a.merge(signature, resp, index, pubkey, digest)
 			if err != nil {
-				dela.Logger.Warn().Err(err).Send()
+				a.logger.Warn().Err(err).Msg("failed to process signature response")
 			} else {
 				count++
 			}
@@ -106,7 +110,7 @@ func (a thresholdActor) waitCtx(inner, upper context.Context, cancel func()) {
 	}
 }
 
-func (a thresholdActor) merge(signature *Signature, m serde.Message,
+func (a thresholdActor) merge(signature *types.Signature, m serde.Message,
 	index int, pubkey crypto.PublicKey, digest []byte) error {
 
 	resp, ok := m.(cosi.SignatureResponse)

--- a/cosi/threshold/handler_test.go
+++ b/cosi/threshold/handler_test.go
@@ -25,6 +25,9 @@ func TestThresholdHandler_Stream(t *testing.T) {
 	err = handler.processRequest(sender, rcvr)
 	require.EqualError(t, err, "failed to receive: oops")
 
+	err = handler.processRequest(sender, &fakeReceiver{resps: makeBadResponse()})
+	require.EqualError(t, err, "invalid request type 'fake.Message'")
+
 	handler.reactor = fakeReactor{err: xerrors.New("oops")}
 	rcvr.err = nil
 	rcvr.resps = makeResponse()
@@ -49,4 +52,8 @@ func TestThresholdHandler_Stream(t *testing.T) {
 
 func makeResponse() [][]interface{} {
 	return [][]interface{}{{fake.Address{}, cosi.SignatureRequest{Value: fake.Message{}}}}
+}
+
+func makeBadResponse() [][]interface{} {
+	return [][]interface{}{{fake.Address{}, fake.Message{}}}
 }

--- a/cosi/threshold/json/mod.go
+++ b/cosi/threshold/json/mod.go
@@ -3,14 +3,14 @@ package json
 import (
 	"encoding/json"
 
-	"go.dedis.ch/dela/cosi/threshold"
+	"go.dedis.ch/dela/cosi/threshold/types"
 	"go.dedis.ch/dela/crypto"
 	"go.dedis.ch/dela/serde"
 	"golang.org/x/xerrors"
 )
 
 func init() {
-	threshold.RegisterSignatureFormat(serde.FormatJSON, sigFormat{})
+	types.RegisterSignatureFormat(serde.FormatJSON, sigFormat{})
 }
 
 // Signature is the JSON message for the signature.
@@ -28,7 +28,7 @@ type sigFormat struct{}
 // Encode implements serde.FormatEngine. It returns the serialized data of the
 // signature message if appropriate, otherwise an error.
 func (f sigFormat) Encode(ctx serde.Context, msg serde.Message) ([]byte, error) {
-	sig, ok := msg.(*threshold.Signature)
+	sig, ok := msg.(*types.Signature)
 	if !ok {
 		return nil, xerrors.Errorf("unsupported message of type '%T'", msg)
 	}
@@ -60,7 +60,7 @@ func (f sigFormat) Decode(ctx serde.Context, data []byte) (serde.Message, error)
 		return nil, xerrors.Errorf("couldn't unmarshal message: %v", err)
 	}
 
-	factory := ctx.GetFactory(threshold.AggKey{})
+	factory := ctx.GetFactory(types.AggKey{})
 
 	fac, ok := factory.(crypto.SignatureFactory)
 	if !ok {
@@ -72,7 +72,7 @@ func (f sigFormat) Decode(ctx serde.Context, data []byte) (serde.Message, error)
 		return nil, xerrors.Errorf("couldn't deserialize signature: %v", err)
 	}
 
-	s := threshold.NewSignature(agg, m.Mask)
+	s := types.NewSignature(agg, m.Mask)
 
 	return s, nil
 }

--- a/cosi/threshold/json/mod_test.go
+++ b/cosi/threshold/json/mod_test.go
@@ -4,16 +4,16 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.dedis.ch/dela/cosi/threshold"
+	"go.dedis.ch/dela/cosi/threshold/types"
 	"go.dedis.ch/dela/internal/testing/fake"
 	"go.dedis.ch/dela/serde"
-	"go.dedis.ch/dela/serde/json"
 )
 
 func TestFormat_Encode(t *testing.T) {
 	format := sigFormat{}
-	sig := threshold.NewSignature(fake.Signature{}, []byte{0xab})
-	ctx := json.NewContext()
+	sig := types.NewSignature(fake.Signature{}, []byte{0xab})
+
+	ctx := fake.NewContext()
 
 	data, err := format.Encode(ctx, sig)
 	require.NoError(t, err)
@@ -25,27 +25,29 @@ func TestFormat_Encode(t *testing.T) {
 	_, err = format.Encode(fake.NewBadContext(), sig)
 	require.EqualError(t, err, "couldn't marshal: fake error")
 
-	sig = threshold.NewSignature(fake.NewBadSignature(), nil)
+	sig = types.NewSignature(fake.NewBadSignature(), nil)
 	_, err = format.Encode(ctx, sig)
 	require.EqualError(t, err, "couldn't serialize aggregate: fake error")
 }
 
 func TestFormat_Decode(t *testing.T) {
 	format := sigFormat{}
-	ctx := serde.WithFactory(json.NewContext(), threshold.AggKey{}, fake.SignatureFactory{})
+
+	ctx := fake.NewContext()
+	ctx = serde.WithFactory(ctx, types.AggKey{}, fake.SignatureFactory{})
 
 	sig, err := format.Decode(ctx, []byte(`{"Mask":[1],"Aggregate":{}}`))
 	require.NoError(t, err)
-	require.Equal(t, []byte{1}, sig.(*threshold.Signature).GetMask())
+	require.Equal(t, []byte{1}, sig.(*types.Signature).GetMask())
 
 	_, err = format.Decode(fake.NewBadContext(), []byte(`{}`))
 	require.EqualError(t, err, "couldn't unmarshal message: fake error")
 
-	ctx = serde.WithFactory(ctx, threshold.AggKey{}, fake.NewBadSignatureFactory())
+	ctx = serde.WithFactory(ctx, types.AggKey{}, fake.NewBadSignatureFactory())
 	_, err = format.Decode(ctx, []byte(`{}`))
 	require.EqualError(t, err, "couldn't deserialize signature: fake error")
 
-	ctx = serde.WithFactory(ctx, threshold.AggKey{}, nil)
+	ctx = serde.WithFactory(ctx, types.AggKey{}, nil)
 	_, err = format.Decode(ctx, []byte(`{}`))
 	require.EqualError(t, err, "invalid factory of type '<nil>'")
 }

--- a/cosi/threshold/mod.go
+++ b/cosi/threshold/mod.go
@@ -39,8 +39,10 @@ func ByzantineThreshold(n int) int {
 // CoSi is an implementation of the cosi.CollectiveSigning interface that is
 // using streams to parallelize the work.
 type CoSi struct {
-	mino      mino.Mino
-	signer    crypto.AggregateSigner
+	mino   mino.Mino
+	signer crypto.AggregateSigner
+	// Stores the cosi.Threshold function. It will always contain a valid
+	// function by construction.
 	threshold atomic.Value
 }
 

--- a/cosi/threshold/mod.go
+++ b/cosi/threshold/mod.go
@@ -1,35 +1,60 @@
 package threshold
 
 import (
+	"sync/atomic"
+
+	"go.dedis.ch/dela"
 	"go.dedis.ch/dela/cosi"
+	"go.dedis.ch/dela/cosi/threshold/types"
 	"go.dedis.ch/dela/crypto"
 	"go.dedis.ch/dela/mino"
 	"golang.org/x/xerrors"
 )
 
-// Threshold is a function that returns the threshold to reach for a given n.
-type Threshold func(int) int
-
 func defaultThreshold(n int) int {
 	return n
+}
+
+// OneThreshold is a threshold function to allow one failure.
+func OneThreshold(n int) int {
+	if n <= 0 {
+		return 0
+	}
+
+	return n - 1
+}
+
+// ByzantineThreshold is a threshold function to allow a threshold number of
+// failures and comply to the Byzantine Fault Tolerance theorem.
+func ByzantineThreshold(n int) int {
+	if n <= 0 {
+		return 0
+	}
+
+	f := (n - 1) / 3
+
+	return n - f
 }
 
 // CoSi is an implementation of the cosi.CollectiveSigning interface that is
 // using streams to parallelize the work.
 type CoSi struct {
-	mino   mino.Mino
-	signer crypto.AggregateSigner
-
-	Threshold Threshold
+	mino      mino.Mino
+	signer    crypto.AggregateSigner
+	threshold atomic.Value
 }
 
 // NewCoSi returns a new instance.
 func NewCoSi(m mino.Mino, signer crypto.AggregateSigner) *CoSi {
-	return &CoSi{
-		mino:      m,
-		signer:    signer,
-		Threshold: defaultThreshold,
+	c := &CoSi{
+		mino:   m,
+		signer: signer,
 	}
+
+	// Force the cosi.Threshold type to allow later updates of the same type.
+	c.threshold.Store(cosi.Threshold(defaultThreshold))
+
+	return c
 }
 
 // GetSigner implements cosi.CollectiveSigning. It returns the signer of the
@@ -47,15 +72,23 @@ func (c *CoSi) GetPublicKeyFactory() crypto.PublicKeyFactory {
 // GetSignatureFactory implements cosi.CollectiveSigning. It returns the
 // signature factory.
 func (c *CoSi) GetSignatureFactory() crypto.SignatureFactory {
-	return SignatureFactory{
-		aggFactory: c.signer.GetSignatureFactory(),
-	}
+	return types.NewSignatureFactory(c.signer.GetSignatureFactory())
 }
 
 // GetVerifierFactory implements cosi.CollectiveSigning. It returns the verifier
 // factory.
 func (c *CoSi) GetVerifierFactory() crypto.VerifierFactory {
-	return verifierFactory{factory: c.signer.GetVerifierFactory()}
+	return types.NewThresholdVerifierFactory(c.signer.GetVerifierFactory())
+}
+
+// SetThreshold implements cosi.CollectiveSigning. It sets a new threshold
+// function.
+func (c *CoSi) SetThreshold(fn cosi.Threshold) {
+	if fn == nil {
+		return
+	}
+
+	c.threshold.Store(fn)
 }
 
 // Listen implements cosi.CollectiveSigning.
@@ -69,6 +102,7 @@ func (c *CoSi) Listen(r cosi.Reactor) (cosi.Actor, error) {
 
 	actor := thresholdActor{
 		CoSi:    c,
+		logger:  dela.Logger.With().Str("addr", c.mino.GetAddress().String()).Logger(),
 		me:      c.mino.GetAddress(),
 		rpc:     rpc,
 		reactor: r,

--- a/cosi/threshold/types/mod.go
+++ b/cosi/threshold/types/mod.go
@@ -1,7 +1,9 @@
-package threshold
+package types
 
 import (
 	"bytes"
+	"fmt"
+	"math/big"
 
 	"go.dedis.ch/dela/crypto"
 	"go.dedis.ch/dela/serde"
@@ -149,6 +151,14 @@ func (s *Signature) Equal(o crypto.Signature) bool {
 	return ok && other.agg.Equal(s.agg) && bytes.Equal(s.mask, other.mask)
 }
 
+// String implements fmt.Stringer. It returns a string representation of the
+// signature.
+func (s *Signature) String() string {
+	mask := new(big.Int).SetBytes(s.mask)
+
+	return fmt.Sprintf("thres[%b]:%s", mask, s.agg)
+}
+
 // AggKey is the key for the aggregate signature factory.
 type AggKey struct{}
 
@@ -245,6 +255,14 @@ func (v Verifier) Verify(msg []byte, s crypto.Signature) error {
 
 type verifierFactory struct {
 	factory crypto.VerifierFactory
+}
+
+// NewThresholdVerifierFactory creates a new verifier factory from the
+// underlying verifier factory.
+func NewThresholdVerifierFactory(fac crypto.VerifierFactory) crypto.VerifierFactory {
+	return verifierFactory{
+		factory: fac,
+	}
 }
 
 func (f verifierFactory) FromAuthority(authority crypto.CollectiveAuthority) (crypto.Verifier, error) {

--- a/cosi/threshold/types/mod_test.go
+++ b/cosi/threshold/types/mod_test.go
@@ -1,4 +1,4 @@
-package threshold
+package types
 
 import (
 	"testing"
@@ -112,6 +112,12 @@ func TestSignature_Equal(t *testing.T) {
 	require.False(t, sig.Equal(nil))
 }
 
+func TestSignature_String(t *testing.T) {
+	sig := NewSignature(fake.Signature{}, []byte{0xa})
+
+	require.Equal(t, "thres[1010]:fakeSignature", sig.String())
+}
+
 func TestSignatureFactory_Deserialize(t *testing.T) {
 	factory := NewSignatureFactory(fake.SignatureFactory{})
 
@@ -147,7 +153,7 @@ func TestVerifier_Verify(t *testing.T) {
 	require.Len(t, call.Get(0, 0), 2)
 
 	err = verifier.Verify([]byte{}, nil)
-	require.EqualError(t, err, "invalid signature type '<nil>' != '*threshold.Signature'")
+	require.EqualError(t, err, "invalid signature type '<nil>' != '*types.Signature'")
 
 	verifier.factory = fake.NewBadVerifierFactory()
 	err = verifier.Verify([]byte{}, &Signature{})
@@ -159,11 +165,13 @@ func TestVerifier_Verify(t *testing.T) {
 }
 
 func TestVerifierFactory_FromArray(t *testing.T) {
-	fac := verifierFactory{
-		factory: fake.NewVerifierFactory(fake.Verifier{}),
-	}
+	fac := NewThresholdVerifierFactory(fake.NewVerifierFactory(fake.Verifier{}))
 
 	verifier, err := fac.FromArray([]crypto.PublicKey{fake.PublicKey{}})
 	require.NoError(t, err)
 	require.Len(t, verifier.(Verifier).pubkeys, 1)
+
+	verifier, err = fac.FromAuthority(fake.NewAuthority(3, fake.NewSigner))
+	require.NoError(t, err)
+	require.Len(t, verifier.(Verifier).pubkeys, 3)
 }

--- a/internal/testing/fake/mod.go
+++ b/internal/testing/fake/mod.go
@@ -358,6 +358,11 @@ func (s Signature) MarshalBinary() ([]byte, error) {
 	return []byte{SignatureByte}, s.err
 }
 
+// String implements fmt.Stringer.
+func (s Signature) String() string {
+	return "fakeSignature"
+}
+
 // SignatureFactory is a fake implementation of the signature factory.
 type SignatureFactory struct {
 	Counter   *Counter

--- a/mino/gossip/flat.go
+++ b/mino/gossip/flat.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/rs/zerolog"
+	"go.dedis.ch/dela"
 	"go.dedis.ch/dela/mino"
 	"go.dedis.ch/dela/serde"
 	"golang.org/x/xerrors"
@@ -45,7 +47,8 @@ func (flat *Flat) Listen() (Actor, error) {
 	}
 
 	actor := &flatActor{
-		rpc: rpc,
+		logger: dela.Logger.With().Str("addr", flat.mino.GetAddress().String()).Logger(),
+		rpc:    rpc,
 	}
 
 	return actor, nil
@@ -60,6 +63,7 @@ func (flat *Flat) Rumors() <-chan Rumor {
 type flatActor struct {
 	sync.Mutex
 
+	logger  zerolog.Logger
 	rpc     mino.RPC
 	players mino.Players
 }
@@ -100,7 +104,7 @@ func (a *flatActor) Add(rumor Rumor) error {
 
 		_, err := resp.GetMessageOrError()
 		if err != nil {
-			return xerrors.Errorf("couldn't send the rumor: %v", err)
+			a.logger.Warn().Err(err).Msg("rumor not sent")
 		}
 	}
 }

--- a/serde/json/mod.go
+++ b/serde/json/mod.go
@@ -13,6 +13,7 @@ import (
 	_ "go.dedis.ch/dela/core/txn/signed/json"
 	_ "go.dedis.ch/dela/core/validation/simple/json"
 	_ "go.dedis.ch/dela/cosi/json"
+	_ "go.dedis.ch/dela/cosi/threshold/json"
 	_ "go.dedis.ch/dela/crypto/bls/json"
 	_ "go.dedis.ch/dela/crypto/ed25519/json"
 	_ "go.dedis.ch/dela/dkg/pedersen/json"


### PR DESCRIPTION
This switches from the flat collective signing to a threshold one for the integration tests.