### PR TITLE
Cosipbft: use a different timeout after a failure

### DIFF
--- a/core/ordering/cosipbft/mod.go
+++ b/core/ordering/cosipbft/mod.go
@@ -51,12 +51,14 @@ type Service struct {
 	val         validation.Service
 	verifierFac crypto.VerifierFactory
 
-	timeoutRound      time.Duration
-	timeoutViewchange time.Duration
+	timeoutRound             time.Duration
+	timeoutRoundAfterFailure time.Duration
+	timeoutViewchange        time.Duration
 
-	events  chan ordering.Event
-	closing chan struct{}
-	closed  chan struct{}
+	events      chan ordering.Event
+	closing     chan struct{}
+	closed      chan struct{}
+	failedRound bool
 }
 
 type serviceTemplate struct {
@@ -108,6 +110,7 @@ func NewService(param ServiceParam, opts ...ServiceOption) (*Service, error) {
 	proc.logger = dela.Logger.With().Str("addr", param.Mino.GetAddress().String()).Logger()
 
 	pcparam := pbft.StateMachineParam{
+		Logger:          proc.logger,
 		Validation:      param.Validation,
 		Signer:          param.Cosi.GetSigner(),
 		VerifierFactory: param.Cosi.GetVerifierFactory(),
@@ -163,17 +166,18 @@ func NewService(param ServiceParam, opts ...ServiceOption) (*Service, error) {
 	}
 
 	s := &Service{
-		processor:         proc,
-		me:                param.Mino.GetAddress(),
-		rpc:               rpc,
-		actor:             actor,
-		val:               param.Validation,
-		verifierFac:       param.Cosi.GetVerifierFactory(),
-		timeoutRound:      RoundTimeout,
-		timeoutViewchange: RoundTimeout,
-		events:            make(chan ordering.Event, 1),
-		closing:           make(chan struct{}),
-		closed:            make(chan struct{}),
+		processor:                proc,
+		me:                       param.Mino.GetAddress(),
+		rpc:                      rpc,
+		actor:                    actor,
+		val:                      param.Validation,
+		verifierFac:              param.Cosi.GetVerifierFactory(),
+		timeoutRound:             RoundTimeout,
+		timeoutRoundAfterFailure: RoundTimeout,
+		timeoutViewchange:        RoundTimeout,
+		events:                   make(chan ordering.Event, 1),
+		closing:                  make(chan struct{}),
+		closed:                   make(chan struct{}),
 	}
 
 	go func() {
@@ -395,8 +399,13 @@ func (s *Service) doRound(ctx context.Context) error {
 		// Only enters the loop if the node is not the leader. It has to wait
 		// for the new block, or the round timeout, to proceed.
 
+		timeout := s.timeoutRound
+		if s.failedRound {
+			timeout = s.timeoutRoundAfterFailure
+		}
+
 		select {
-		case <-time.After(s.timeoutRound):
+		case <-time.After(timeout):
 			if s.pool.Len() == 0 {
 				// When the pool of transactions is empty, the round is aborted
 				// and everything restart.
@@ -404,6 +413,9 @@ func (s *Service) doRound(ctx context.Context) error {
 			}
 
 			s.logger.Warn().Msg("round reached the timeout")
+
+			// Mark that the view change happened during this round.
+			s.failedRound = true
 
 			ctx, cancel := context.WithTimeout(ctx, s.timeoutViewchange)
 
@@ -446,6 +458,8 @@ func (s *Service) doRound(ctx context.Context) error {
 			cancel()
 			return nil
 		case <-s.events:
+			s.failedRound = false
+
 			// A block has been created meaning that the round is over.
 			return nil
 		case <-s.closing:

--- a/core/ordering/cosipbft/mod_test.go
+++ b/core/ordering/cosipbft/mod_test.go
@@ -96,9 +96,11 @@ func TestService_Scenario_ViewChange(t *testing.T) {
 	defer clean()
 
 	for _, node := range nodes {
-		// Must be high enough for slow machines.
-		node.service.timeoutRound = 500 * time.Millisecond
-		node.service.timeoutViewchange = 10 * time.Second
+		// Short timeout to for the first round that we want to fail.
+		node.service.timeoutRound = 50 * time.Millisecond
+		// Long enough timeout so that any slow machine won't fail the test.
+		node.service.timeoutRoundAfterFailure = 30 * time.Second
+		node.service.timeoutViewchange = 30 * time.Second
 	}
 
 	// Simulate an issue with the leader transaction pool so that it does not

--- a/core/ordering/cosipbft/pbft/mod.go
+++ b/core/ordering/cosipbft/pbft/mod.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 
 	"github.com/rs/zerolog"
-	"go.dedis.ch/dela"
 	"go.dedis.ch/dela/core"
 	"go.dedis.ch/dela/core/ordering/cosipbft/authority"
 	"go.dedis.ch/dela/core/ordering/cosipbft/blockstore"
@@ -117,6 +116,7 @@ type pbftsm struct {
 // StateMachineParam is a structure to pass the different components of the PBFT
 // state machine.
 type StateMachineParam struct {
+	Logger          zerolog.Logger
 	Validation      validation.Service
 	VerifierFactory crypto.VerifierFactory
 	Signer          crypto.Signer
@@ -130,7 +130,7 @@ type StateMachineParam struct {
 // NewStateMachine returns a new state machine.
 func NewStateMachine(param StateMachineParam) StateMachine {
 	return &pbftsm{
-		logger:      dela.Logger,
+		logger:      param.Logger,
 		watcher:     core.NewWatcher(),
 		hashFac:     crypto.NewSha256Factory(),
 		val:         param.Validation,


### PR DESCRIPTION
This changes the behavior to use a different timeout after a view change happened. This is mainly for unit testing to work with slow machines but it also makes sense in production deployment.