### PR TITLE
Fix minogrpc test

### DIFF
--- a/mino/minogrpc/mod_test.go
+++ b/mino/minogrpc/mod_test.go
@@ -25,7 +25,7 @@ func TestMinogrpc_New(t *testing.T) {
 
 	cert := m.GetCertificate()
 	require.NotNil(t, cert)
-
+	<-m.started
 	require.NoError(t, m.GracefulStop())
 
 	addr = ParseAddress("123.4.5.6", 1)


### PR DESCRIPTION
This fixes a test where the instance is closed before it actually started
which is producing an error on gRPC side.