### PR TITLE
ViewChange: check only one tx per block

### DIFF
--- a/core/execution/baremetal/mod.go
+++ b/core/execution/baremetal/mod.go
@@ -3,7 +3,6 @@ package baremetal
 import (
 	"go.dedis.ch/dela/core/execution"
 	"go.dedis.ch/dela/core/store"
-	"go.dedis.ch/dela/core/txn"
 	"golang.org/x/xerrors"
 )
 
@@ -15,7 +14,7 @@ const (
 // Contract is the interface to implement to register a smart contract that will
 // be executed natively.
 type Contract interface {
-	Execute(txn.Transaction, store.Snapshot) error
+	Execute(store.Snapshot, execution.Step) error
 }
 
 // BareMetal is an execution service for packaged applications. Those
@@ -42,8 +41,8 @@ func (bm *BareMetal) Set(name string, contract Contract) {
 
 // Execute implements execution.Service. It uses the executor to process the
 // incoming transaction and return the result.
-func (bm *BareMetal) Execute(tx txn.Transaction, snap store.Snapshot) (execution.Result, error) {
-	name := string(tx.GetArg(ContractArg))
+func (bm *BareMetal) Execute(snap store.Snapshot, step execution.Step) (execution.Result, error) {
+	name := string(step.Current.GetArg(ContractArg))
 
 	contract := bm.contracts[name]
 	if contract == nil {
@@ -54,7 +53,7 @@ func (bm *BareMetal) Execute(tx txn.Transaction, snap store.Snapshot) (execution
 		Accepted: true,
 	}
 
-	err := contract.Execute(tx, snap)
+	err := contract.Execute(snap, step)
 	if err != nil {
 		res.Accepted = false
 		res.Message = err.Error()

--- a/core/execution/baremetal/mod_test.go
+++ b/core/execution/baremetal/mod_test.go
@@ -15,15 +15,20 @@ func TestBareMetal_Execute(t *testing.T) {
 	srvc.Set("abc", fakeExec{})
 	srvc.Set("bad", fakeExec{err: fake.GetError()})
 
-	res, err := srvc.Execute(fakeTx{contract: "abc"}, nil)
+	step := execution.Step{}
+	step.Current = fakeTx{contract: "abc"}
+
+	res, err := srvc.Execute(nil, step)
 	require.NoError(t, err)
 	require.Equal(t, execution.Result{Accepted: true}, res)
 
-	res, err = srvc.Execute(fakeTx{contract: "bad"}, nil)
+	step.Current = fakeTx{contract: "bad"}
+	res, err = srvc.Execute(nil, step)
 	require.NoError(t, err)
 	require.Equal(t, execution.Result{Message: fake.GetError().Error()}, res)
 
-	_, err = srvc.Execute(fakeTx{contract: "none"}, nil)
+	step.Current = fakeTx{contract: "none"}
+	_, err = srvc.Execute(nil, step)
 	require.EqualError(t, err, "unknown contract 'none'")
 }
 
@@ -34,7 +39,7 @@ type fakeExec struct {
 	err error
 }
 
-func (e fakeExec) Execute(txn.Transaction, store.Snapshot) error {
+func (e fakeExec) Execute(store.Snapshot, execution.Step) error {
 	return e.err
 }
 

--- a/core/execution/mod.go
+++ b/core/execution/mod.go
@@ -5,6 +5,12 @@ import (
 	"go.dedis.ch/dela/core/txn"
 )
 
+// Step is a context of execution.
+type Step struct {
+	Previous []txn.Transaction
+	Current  txn.Transaction
+}
+
 // Result is the result of a transaction execution.
 type Result struct {
 	// Accepted is the success state of the transaction.
@@ -20,5 +26,5 @@ type Result struct {
 type Service interface {
 	// Execute must apply the transaction to the trie and return the result of
 	// it.
-	Execute(tx txn.Transaction, snap store.Snapshot) (Result, error)
+	Execute(snap store.Snapshot, step Step) (Result, error)
 }

--- a/core/execution/mod.go
+++ b/core/execution/mod.go
@@ -5,7 +5,9 @@ import (
 	"go.dedis.ch/dela/core/txn"
 )
 
-// Step is a context of execution.
+// Step is a context of execution. It allows for example a smart contract to
+// execute a given transaction knowing what previous transactions have already
+// been accepted and executed in a block.
 type Step struct {
 	Previous []txn.Transaction
 	Current  txn.Transaction

--- a/core/ordering/cosipbft/mod_test.go
+++ b/core/ordering/cosipbft/mod_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.dedis.ch/dela/core/access"
 	"go.dedis.ch/dela/core/access/darc"
+	"go.dedis.ch/dela/core/execution"
 	"go.dedis.ch/dela/core/execution/baremetal"
 	"go.dedis.ch/dela/core/execution/baremetal/viewchange"
 	"go.dedis.ch/dela/core/ordering"
@@ -483,7 +484,7 @@ type testExec struct {
 	err error
 }
 
-func (e testExec) Execute(txn.Transaction, store.Snapshot) error {
+func (e testExec) Execute(store.Snapshot, execution.Step) error {
 	return e.err
 }
 

--- a/core/ordering/cosipbft/pbft/mod_test.go
+++ b/core/ordering/cosipbft/pbft/mod_test.go
@@ -532,7 +532,7 @@ type fakeExec struct {
 	err error
 }
 
-func (e fakeExec) Execute(txn.Transaction, store.Snapshot) (execution.Result, error) {
+func (e fakeExec) Execute(store.Snapshot, execution.Step) (execution.Result, error) {
 	return execution.Result{}, e.err
 }
 

--- a/core/ordering/pow/mod_test.go
+++ b/core/ordering/pow/mod_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.dedis.ch/dela/core/execution"
 	"go.dedis.ch/dela/core/execution/baremetal"
 	"go.dedis.ch/dela/core/store"
 	"go.dedis.ch/dela/core/store/hashtree"
@@ -153,9 +154,9 @@ func makeTx(t *testing.T, nonce uint64, signer crypto.Signer) txn.Transaction {
 
 type testExec struct{}
 
-func (e testExec) Execute(tx txn.Transaction, store store.Snapshot) error {
-	key := tx.GetArg("key")
-	value := tx.GetArg("value")
+func (e testExec) Execute(store store.Snapshot, step execution.Step) error {
+	key := step.Current.GetArg("key")
+	value := step.Current.GetArg("value")
 
 	if len(key) == 0 || len(value) == 0 {
 		return xerrors.New("key or value is nil")

--- a/core/txn/pool/gossip/mod_test.go
+++ b/core/txn/pool/gossip/mod_test.go
@@ -178,7 +178,7 @@ func TestPool_ListenRumors(t *testing.T) {
 	p.gatherer = badGatherer{}
 	p.closing = make(chan struct{})
 
-	ch = make(chan gossip.Rumor, 1)
+	ch = make(chan gossip.Rumor)
 	go func() {
 		ch <- makeTx(0)
 		close(p.closing)

--- a/core/validation/simple/mod.go
+++ b/core/validation/simple/mod.go
@@ -67,12 +67,22 @@ func (s Service) GetNonce(store store.Readable, ident access.Identity) (uint64, 
 func (s Service) Validate(store store.Snapshot, txs []txn.Transaction) (validation.Data, error) {
 	results := make([]TransactionResult, len(txs))
 
+	step := execution.Step{
+		Previous: make([]txn.Transaction, 0, len(txs)),
+	}
+
 	for i, tx := range txs {
 		res := TransactionResult{tx: tx}
 
-		err := s.validateTx(store, tx, &res)
+		step.Current = tx
+
+		err := s.validateTx(store, step, &res)
 		if err != nil {
 			return nil, xerrors.Errorf("tx %#x: %v", tx.GetID()[:4], err)
+		}
+
+		if res.accepted {
+			step.Previous = append(step.Previous, tx)
 		}
 
 		results[i] = res
@@ -85,19 +95,19 @@ func (s Service) Validate(store store.Snapshot, txs []txn.Transaction) (validati
 	return data, nil
 }
 
-func (s Service) validateTx(store store.Snapshot, tx txn.Transaction, r *TransactionResult) error {
-	expectedNonce, err := s.GetNonce(store, tx.GetIdentity())
+func (s Service) validateTx(store store.Snapshot, step execution.Step, r *TransactionResult) error {
+	expectedNonce, err := s.GetNonce(store, step.Current.GetIdentity())
 	if err != nil {
 		return xerrors.Errorf("nonce: %v", err)
 	}
 
-	if expectedNonce != tx.GetNonce() {
+	if expectedNonce != step.Current.GetNonce() {
 		r.reason = "nonce is invalid"
 		r.accepted = false
 		return nil
 	}
 
-	res, err := s.execution.Execute(tx, store)
+	res, err := s.execution.Execute(store, step)
 	if err != nil {
 		// This is a critical error unrelated to the transaction itself.
 		return xerrors.Errorf("failed to execute tx: %v", err)
@@ -108,7 +118,7 @@ func (s Service) validateTx(store store.Snapshot, tx txn.Transaction, r *Transac
 
 	// Update the nonce associated to the identity so that this transaction
 	// cannot be applied again.
-	err = s.set(store, tx.GetIdentity(), tx.GetNonce())
+	err = s.set(store, step.Current.GetIdentity(), step.Current.GetNonce())
 	if err != nil {
 		return xerrors.Errorf("failed to set nonce: %v", err)
 	}


### PR DESCRIPTION
This improves the execution service to include previous transactions
so that view change can make sure only one is accepted per block.