### PR TITLE
Memcoin: fix signal issues with Windows during tests

### DIFF
--- a/cli/node/builder.go
+++ b/cli/node/builder.go
@@ -24,6 +24,7 @@ type cliBuilder struct {
 	daemonFactory DaemonFactory
 	injector      Injector
 	actions       *actionMap
+	enableSignal  bool
 	sigs          chan os.Signal
 	startFlags    []cli.Flag
 	commands      []*cliCommand
@@ -42,8 +43,11 @@ func NewBuilderWithCfg(sigs chan os.Signal, out io.Writer, inits ...Initializer)
 		out = os.Stdout
 	}
 
+	enabled := false
+
 	if sigs == nil {
 		sigs = make(chan os.Signal, 1)
+		enabled = true
 	}
 
 	injector := &reflectInjector{
@@ -62,6 +66,7 @@ func NewBuilderWithCfg(sigs chan os.Signal, out io.Writer, inits ...Initializer)
 		injector:      injector,
 		actions:       actions,
 		daemonFactory: factory,
+		enableSignal:  enabled,
 		sigs:          sigs,
 		inits:         inits,
 		writer:        out,
@@ -181,6 +186,12 @@ func (b *cliBuilder) Build() cli.Application {
 }
 
 func (b *cliBuilder) start(c *ucli.Context) error {
+	if b.enableSignal {
+		signal.Notify(b.sigs, syscall.SIGINT, syscall.SIGTERM)
+
+		defer signal.Stop(b.sigs)
+	}
+
 	dir := c.Path("config")
 	if dir != "" {
 		err := os.MkdirAll(dir, 0700)
@@ -210,10 +221,8 @@ func (b *cliBuilder) start(c *ucli.Context) error {
 
 	defer daemon.Close()
 
-	signal.Notify(b.sigs, syscall.SIGINT, syscall.SIGTERM)
-	defer signal.Stop(b.sigs)
-
 	<-b.sigs
+	signal.Stop(b.sigs)
 
 	// Controllers are stopped in reverse order so that high level components
 	// are stopped before lower level ones (i.e. stop a service before the

--- a/cli/node/builder.go
+++ b/cli/node/builder.go
@@ -24,12 +24,15 @@ type cliBuilder struct {
 	daemonFactory DaemonFactory
 	injector      Injector
 	actions       *actionMap
-	enableSignal  bool
-	sigs          chan os.Signal
 	startFlags    []cli.Flag
 	commands      []*cliCommand
 	inits         []Initializer
 	writer        io.Writer
+
+	// In production, the daemon is stopped via SIGTERM. In case of testing, the
+	// channel will be closed instead, because of instability.
+	enableSignal bool
+	sigs         chan os.Signal
 }
 
 // NewBuilder returns a new empty builder.

--- a/cli/node/daemon.go
+++ b/cli/node/daemon.go
@@ -129,6 +129,10 @@ func (d *socketDaemon) handleConn(conn net.Conn) {
 		return
 	}
 
+	dela.Logger.Debug().
+		Str("flags", fmt.Sprintf("%v", fset)).
+		Msg("received command on the daemon")
+
 	actx := Context{
 		Injector: d.injector,
 		Flags:    fset,

--- a/cli/node/daemon_test.go
+++ b/cli/node/daemon_test.go
@@ -80,8 +80,9 @@ func TestSocketDaemon_Listen(t *testing.T) {
 
 	out := new(bytes.Buffer)
 	client := socketClient{
-		socketpath: daemon.socketpath,
-		out:        out,
+		socketpath:  daemon.socketpath,
+		out:         out,
+		dialTimeout: time.Second,
 	}
 
 	err = client.Send(append([]byte{0x0, 0x0}, []byte("{}")...))

--- a/cli/node/memcoin/mod.go
+++ b/cli/node/memcoin/mod.go
@@ -46,9 +46,7 @@ func main() {
 }
 
 func run(args []string) error {
-	sigs := make(chan os.Signal, 1)
-
-	return runWithCfg(args, config{Channel: sigs, Writer: os.Stdout})
+	return runWithCfg(args, config{Writer: os.Stdout})
 }
 
 type config struct {

--- a/cli/node/memcoin/mod_test.go
+++ b/cli/node/memcoin/mod_test.go
@@ -54,7 +54,7 @@ func TestMemcoin_Scenario_SetupAndTransactions(t *testing.T) {
 		wg.Wait()
 	}()
 
-	require.True(t, waitDaemon(t, []string{node1, node2, node3}), "timeout")
+	require.True(t, waitDaemon(t, []string{node1, node2, node3}), "daemon failed to start")
 
 	// Share the certificates.
 	shareCert(t, node2, node1, "127.0.0.1:2111")
@@ -151,7 +151,7 @@ func TestMemcoin_Scenario_RestartNode(t *testing.T) {
 		wg.Wait()
 	}()
 
-	require.True(t, waitDaemon(t, []string{node1, node2}), "timeout")
+	require.True(t, waitDaemon(t, []string{node1, node2}), "daemon failed to start")
 
 	args := append([]string{
 		os.Args[0],


### PR DESCRIPTION
Because the tests were listening for the terminate signal, that was causing some instability. It now only waits for the channel to be closed in the test, and listen for the signal in production.