### PR TITLE
Documentation: update mino packages documentation

### DIFF
--- a/core/ordering/cosipbft/blockstore/mem_test.go
+++ b/core/ordering/cosipbft/blockstore/mem_test.go
@@ -170,7 +170,7 @@ func TestObserver_Flooding_NotifyCallback(t *testing.T) {
 
 	obs := &observer{
 		logger: logger,
-		ch:     make(chan types.BlockLink, 1),
+		ch:     make(chan types.BlockLink),
 	}
 
 	link := makeLink(t, types.Digest{})

--- a/core/ordering/cosipbft/blocksync/default_test.go
+++ b/core/ordering/cosipbft/blocksync/default_test.go
@@ -280,7 +280,7 @@ func makeNodes(t *testing.T, n int) ([]defaultSync, otypes.Genesis, mino.Players
 	require.NoError(t, err)
 
 	for i := 0; i < n; i++ {
-		m := minoch.NewMinoch(manager, fmt.Sprintf("node%d", i))
+		m := minoch.MustCreate(manager, fmt.Sprintf("node%d", i))
 
 		addrs[i] = m.GetAddress()
 

--- a/core/ordering/cosipbft/blocksync/default_test.go
+++ b/core/ordering/cosipbft/blocksync/default_test.go
@@ -280,8 +280,7 @@ func makeNodes(t *testing.T, n int) ([]defaultSync, otypes.Genesis, mino.Players
 	require.NoError(t, err)
 
 	for i := 0; i < n; i++ {
-		m, err := minoch.NewMinoch(manager, fmt.Sprintf("node%d", i))
-		require.NoError(t, err)
+		m := minoch.NewMinoch(manager, fmt.Sprintf("node%d", i))
 
 		addrs[i] = m.GetAddress()
 

--- a/core/ordering/cosipbft/mod_test.go
+++ b/core/ordering/cosipbft/mod_test.go
@@ -601,7 +601,7 @@ func makeAuthority(t *testing.T, n int) ([]testNode, authority.Authority, func()
 	nodes := make([]testNode, n)
 
 	for i := 0; i < n; i++ {
-		m := minoch.NewMinoch(manager, fmt.Sprintf("node%d", i))
+		m := minoch.MustCreate(manager, fmt.Sprintf("node%d", i))
 
 		addrs[i] = m.GetAddress()
 

--- a/core/ordering/cosipbft/mod_test.go
+++ b/core/ordering/cosipbft/mod_test.go
@@ -601,8 +601,7 @@ func makeAuthority(t *testing.T, n int) ([]testNode, authority.Authority, func()
 	nodes := make([]testNode, n)
 
 	for i := 0; i < n; i++ {
-		m, err := minoch.NewMinoch(manager, fmt.Sprintf("node%d", i))
-		require.NoError(t, err)
+		m := minoch.NewMinoch(manager, fmt.Sprintf("node%d", i))
 
 		addrs[i] = m.GetAddress()
 

--- a/core/txn/pool/gossip/mod_test.go
+++ b/core/txn/pool/gossip/mod_test.go
@@ -210,8 +210,7 @@ func makeRoster(t *testing.T, n int) (mino.Players, []*Pool) {
 	addrs := make([]mino.Address, n)
 
 	for i := 0; i < n; i++ {
-		m, err := minoch.NewMinoch(manager, fmt.Sprintf("node%d", i))
-		require.NoError(t, err)
+		m := minoch.NewMinoch(manager, fmt.Sprintf("node%d", i))
 
 		addrs[i] = m.GetAddress()
 

--- a/core/txn/pool/gossip/mod_test.go
+++ b/core/txn/pool/gossip/mod_test.go
@@ -210,7 +210,7 @@ func makeRoster(t *testing.T, n int) (mino.Players, []*Pool) {
 	addrs := make([]mino.Address, n)
 
 	for i := 0; i < n; i++ {
-		m := minoch.NewMinoch(manager, fmt.Sprintf("node%d", i))
+		m := minoch.MustCreate(manager, fmt.Sprintf("node%d", i))
 
 		addrs[i] = m.GetAddress()
 

--- a/cosi/flatcosi/example_test.go
+++ b/cosi/flatcosi/example_test.go
@@ -18,8 +18,8 @@ func Example() {
 	// Create the network overlay instances. It uses channels to communicate.
 	manager := minoch.NewManager()
 
-	mA := minoch.NewMinoch(manager, "A")
-	mB := minoch.NewMinoch(manager, "B")
+	mA := minoch.MustCreate(manager, "A")
+	mB := minoch.MustCreate(manager, "B")
 
 	// The list of participants to the signature.
 	roster := fake.NewAuthorityFromMino(bls.Generate, mA, mB)

--- a/cosi/flatcosi/example_test.go
+++ b/cosi/flatcosi/example_test.go
@@ -18,15 +18,8 @@ func Example() {
 	// Create the network overlay instances. It uses channels to communicate.
 	manager := minoch.NewManager()
 
-	mA, err := minoch.NewMinoch(manager, "A")
-	if err != nil {
-		panic(fmt.Sprintf("failed to serve A: %+v", err))
-	}
-
-	mB, err := minoch.NewMinoch(manager, "B")
-	if err != nil {
-		panic(fmt.Sprintf("failed to serve B: %+v", err))
-	}
+	mA := minoch.NewMinoch(manager, "A")
+	mB := minoch.NewMinoch(manager, "B")
 
 	// The list of participants to the signature.
 	roster := fake.NewAuthorityFromMino(bls.Generate, mA, mB)

--- a/cosi/threshold/mod_test.go
+++ b/cosi/threshold/mod_test.go
@@ -17,11 +17,8 @@ import (
 func TestThreshold_Scenario_Basic(t *testing.T) {
 	manager := minoch.NewManager()
 
-	m1, err := minoch.NewMinoch(manager, "A")
-	require.NoError(t, err)
-
-	m2, err := minoch.NewMinoch(manager, "B")
-	require.NoError(t, err)
+	m1 := minoch.NewMinoch(manager, "A")
+	m2 := minoch.NewMinoch(manager, "B")
 
 	ca := fake.NewAuthorityFromMino(bls.Generate, m1, m2)
 	c1 := NewThreshold(m1, ca.GetSigner(0).(crypto.AggregateSigner))

--- a/cosi/threshold/mod_test.go
+++ b/cosi/threshold/mod_test.go
@@ -17,8 +17,8 @@ import (
 func TestThreshold_Scenario_Basic(t *testing.T) {
 	manager := minoch.NewManager()
 
-	m1 := minoch.NewMinoch(manager, "A")
-	m2 := minoch.NewMinoch(manager, "B")
+	m1 := minoch.MustCreate(manager, "A")
+	m2 := minoch.MustCreate(manager, "B")
 
 	ca := fake.NewAuthorityFromMino(bls.Generate, m1, m2)
 	c1 := NewThreshold(m1, ca.GetSigner(0).(crypto.AggregateSigner))

--- a/mino/addr.go
+++ b/mino/addr.go
@@ -1,6 +1,10 @@
+//
+// Documentation Last Review: 07.10.2020
+//
+
 package mino
 
-// NewAddressIterator returns a new address iterator
+// NewAddressIterator returns a new address iterator.
 func NewAddressIterator(addrs []Address) AddressIterator {
 	return &addressIterator{
 		addrs: addrs,
@@ -15,7 +19,9 @@ type addressIterator struct {
 	addrs []Address
 }
 
-// Seek implements mino.AddressIterator.
+// Seek implements mino.AddressIterator. It moves the iterator to a specific
+// position. The next address can be either defined or nil, it is the
+// responsibility of the caller to verify.
 func (it *addressIterator) Seek(index int) {
 	it.index = index
 }
@@ -34,8 +40,8 @@ func (it *addressIterator) GetNext() Address {
 	return res
 }
 
-// roster is an implementation of the mino.Players interface. It provides helper
-// when known addresses need to be grouped into a roster for Mino calls.
+// roster is an implementation of the players interface. It provides helper when
+// known addresses need to be grouped into a roster for Mino calls.
 //
 // - implements mino.Players
 type roster struct {

--- a/mino/gossip/flat.go
+++ b/mino/gossip/flat.go
@@ -1,3 +1,7 @@
+//
+// Documentation Last Review: 06.10.2020
+//
+
 package gossip
 
 import (
@@ -17,7 +21,7 @@ const (
 )
 
 // Flat is an implementation of a message passing protocol that is using a flat
-// communication approach.
+// communication approach by sending a rumor to all the known participants.
 //
 // - implements gossip.Gossiper
 type Flat struct {
@@ -60,6 +64,10 @@ func (flat *Flat) Rumors() <-chan Rumor {
 	return flat.ch
 }
 
+// flatActor is the actor returned by the gossiper that provide the primitives
+// to send a rumor.
+//
+// - implements gossip.Actor
 type flatActor struct {
 	sync.Mutex
 

--- a/mino/gossip/mod.go
+++ b/mino/gossip/mod.go
@@ -1,3 +1,8 @@
+// Package gossip defines an abstraction to gossip messages to a defined set of
+// participants.
+//
+// Documentation Last Review: 06.10.2020
+//
 package gossip
 
 import (
@@ -16,24 +21,24 @@ type Rumor interface {
 
 // Actor is an actor that can send rumor to a gossip network.
 type Actor interface {
-	// SetPlayers should change the list of participants that the actor should
-	// send rumors to. It is up to the implementation to send to only a subset.
+	// SetPlayers changes the list of participants that the actor should send
+	// rumors to. It is up to the implementation to send to only a subset.
 	SetPlayers(mino.Players)
 
-	// Add should add the rumor in the set of rumors that must be spread to the
+	// Add adds the rumor in the set of rumors that must be spread to the
 	// participants.
 	Add(rumor Rumor) error
 
-	// Close should clean any resource used by the actor.
+	// Close cleans any resource used by the actor.
 	Close() error
 }
 
 // Gossiper is an abstraction of a message passing protocol that uses internally
 // a gossip protocol.
 type Gossiper interface {
-	// Rumors should return a channel populated with the new rumors.
+	// Rumors returns a channel populated with the new rumors.
 	Rumors() <-chan Rumor
 
-	// Listen should start to listen for rumors and returns a gossip actor.
+	// Listen starts to listen for rumors and returns a gossip actor.
 	Listen() (Actor, error)
 }

--- a/mino/minoch/address.go
+++ b/mino/minoch/address.go
@@ -1,3 +1,9 @@
+// This file implements the address abstraction for an in-memory implementation.
+// Each address uses a unique string to identify the instance it belongs to.
+//
+// Documentation Last Review: 06.10.2020
+//
+
 package minoch
 
 import (
@@ -6,6 +12,8 @@ import (
 )
 
 // Address is the representation of an identifier for minoch.
+//
+// - implements mino.Address
 type address struct {
 	orchestrator bool
 	id           string
@@ -17,22 +25,26 @@ func (a address) Equal(other mino.Address) bool {
 	return ok && addr.id == a.id
 }
 
-// MarshalText returns the string representation of an address.
+// MarshalText implements encoding.TextMarshaler. It returns the string
+// representation of an address.
 func (a address) MarshalText() ([]byte, error) {
 	return []byte(a.id), nil
 }
 
-// String returns the address as a string.
+// String implements fmt.Stringer. It returns the address as a string.
 func (a address) String() string {
 	return a.id
 }
 
-// AddressFactory is an implementation of the factory interface.
+// AddressFactory is a factory to deserialize Minoch addresses.
+//
+// - implements mino.AddressFactory
 type AddressFactory struct {
 	serde.Factory
 }
 
-// FromText returns an instance of an address from a byte slice.
+// FromText implements mino.AddressFactory. It returns an instance of an address
+// from a byte slice.
 func (f AddressFactory) FromText(text []byte) mino.Address {
 	return address{id: string(text)}
 }

--- a/mino/minoch/example_test.go
+++ b/mino/minoch/example_test.go
@@ -11,8 +11,8 @@ import (
 func ExampleRPC_Call() {
 	manager := NewManager()
 
-	minoA := NewMinoch(manager, "A")
-	minoB := NewMinoch(manager, "B")
+	minoA := MustCreate(manager, "A")
+	minoB := MustCreate(manager, "B")
 
 	roster := mino.NewAddresses(minoA.GetAddress(), minoB.GetAddress())
 

--- a/mino/minoch/example_test.go
+++ b/mino/minoch/example_test.go
@@ -1,0 +1,96 @@
+package minoch
+
+import (
+	"context"
+	"fmt"
+
+	"go.dedis.ch/dela/mino"
+	"go.dedis.ch/dela/serde"
+)
+
+func ExampleRPC_Call() {
+	manager := NewManager()
+
+	minoA := NewMinoch(manager, "A")
+	minoB := NewMinoch(manager, "B")
+
+	roster := mino.NewAddresses(minoA.GetAddress(), minoB.GetAddress())
+
+	nsA, err := minoA.MakeNamespace("example")
+	if err != nil {
+		panic("namespace failed: " + err.Error())
+	}
+
+	rpcA, err := nsA.MakeRPC("hello", exampleHandler{}, exampleFactory{})
+	if err != nil {
+		panic("rpc failed: " + err.Error())
+	}
+
+	nsB, err := minoB.MakeNamespace("example")
+	if err != nil {
+		panic("namespace failed: " + err.Error())
+	}
+
+	_, err = nsB.MakeRPC("hello", exampleHandler{}, exampleFactory{})
+	if err != nil {
+		panic("rpc failed: " + err.Error())
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	msg := exampleMessage{value: "Hello World!"}
+
+	resps, err := rpcA.Call(ctx, msg, roster)
+	if err != nil {
+		panic("call failed: " + err.Error())
+	}
+
+	for resp := range resps {
+		reply, err := resp.GetMessageOrError()
+		if err != nil {
+			panic("error in response: " + err.Error())
+		}
+
+		fmt.Println(reply.(exampleMessage).value)
+	}
+
+	// Output: Hello World!
+	// Hello World!
+}
+
+// exampleHandler is an RPC handler example.
+//
+// - implements mino.Handler
+type exampleHandler struct {
+	mino.UnsupportedHandler
+}
+
+// Process implements mino.Handler. It returns the message received.
+func (exampleHandler) Process(req mino.Request) (serde.Message, error) {
+	return req.Message, nil
+}
+
+// exampleMessage is an example of a message.
+//
+// - implements serde.Message
+type exampleMessage struct {
+	value string
+}
+
+// Serialize implements serde.Message. It returns the value contained in the
+// message.
+func (m exampleMessage) Serialize(serde.Context) ([]byte, error) {
+	return []byte(m.value), nil
+}
+
+// exampleFactory is an example of a factory.
+//
+// - implements serde.Factory
+type exampleFactory struct{}
+
+// Deserialize implements serde.Factory. It returns the message using data as
+// the inner value.
+func (exampleFactory) Deserialize(ctx serde.Context, data []byte) (serde.Message, error) {
+	return exampleMessage{value: string(data)}, nil
+}

--- a/mino/minoch/manager.go
+++ b/mino/minoch/manager.go
@@ -1,3 +1,9 @@
+// This file implements a manager that will connect the different instances of
+// Minoch so that they can communicate between each others.
+//
+// Documentation Last Review: 06.10.2020
+//
+
 package minoch
 
 import (
@@ -7,8 +13,7 @@ import (
 	"golang.org/x/xerrors"
 )
 
-// Manager is an orchestrator to manage the communication between the local
-// instances of Mino.
+// Manager manages the communication between the local instances of Mino.
 type Manager struct {
 	sync.Mutex
 	instances map[string]*Minoch

--- a/mino/minoch/mod.go
+++ b/mino/minoch/mod.go
@@ -1,5 +1,16 @@
-// Package minoch is an implementation of MINO that is using channels and a
+// Package minoch is an implementation of Mino that is using channels and a
 // local manager to exchange messages.
+//
+// Because it is using only Go channels to communicate, this implementation can
+// only be used by multiple instances in the same process. Its usage is purely
+// to simplify the writing of tests, therefore it also provides some additionnal
+// functionalities like filters.
+//
+// A filter is called for any message incoming and it will determine if the
+// instance should drop the message.
+//
+// Documentation Last Review: 06.10.2020
+//
 package minoch
 
 import (
@@ -18,8 +29,11 @@ type Filter func(mino.Request) bool
 
 // Minoch is an implementation of the Mino interface using channels. Each
 // instance must have a unique string assigned to it.
+//
+// - implements mino.Mino
 type Minoch struct {
 	sync.Mutex
+
 	manager    *Manager
 	identifier string
 	path       string
@@ -29,7 +43,7 @@ type Minoch struct {
 }
 
 // NewMinoch creates a new instance of a local Mino instance.
-func NewMinoch(manager *Manager, identifier string) (*Minoch, error) {
+func NewMinoch(manager *Manager, identifier string) *Minoch {
 	inst := &Minoch{
 		manager:    manager,
 		identifier: identifier,
@@ -40,21 +54,21 @@ func NewMinoch(manager *Manager, identifier string) (*Minoch, error) {
 
 	err := manager.insert(inst)
 	if err != nil {
-		return nil, err
+		panic("manager refused: " + err.Error())
 	}
 
 	dela.Logger.Trace().Msgf("New instance with identifier %s", identifier)
 
-	return inst, nil
+	return inst
 }
 
-// GetAddressFactory returns the address factory.
+// GetAddressFactory implements mino.Mino. It returns the address factory.
 func (m *Minoch) GetAddressFactory() mino.AddressFactory {
 	return AddressFactory{}
 }
 
-// GetAddress returns the address that other participants should use to contact
-// this instance.
+// GetAddress implements mino.Mino. It returns the address that other
+// participants should use to contact this instance.
 func (m *Minoch) GetAddress() mino.Address {
 	return address{id: m.identifier}
 }
@@ -69,7 +83,8 @@ func (m *Minoch) AddFilter(filter Filter) {
 	}
 }
 
-// MakeNamespace returns an instance restricted to the namespace.
+// MakeNamespace implements mino.Mino. It returns an instance restricted to the
+// namespace.
 func (m *Minoch) MakeNamespace(path string) (mino.Mino, error) {
 	newMinoch := &Minoch{
 		manager:    m.manager,
@@ -81,7 +96,8 @@ func (m *Minoch) MakeNamespace(path string) (mino.Mino, error) {
 	return newMinoch, nil
 }
 
-// MakeRPC creates an RPC that can send to and receive from the unique path.
+// MakeRPC implements mino.Mino. It creates an RPC that can send to and receive
+// from the unique path.
 func (m *Minoch) MakeRPC(name string, h mino.Handler, f serde.Factory) (mino.RPC, error) {
 	rpc := &RPC{
 		manager: m.manager,

--- a/mino/minoch/mod_test.go
+++ b/mino/minoch/mod_test.go
@@ -12,21 +12,23 @@ import (
 func TestMinoch_New(t *testing.T) {
 	manager := NewManager()
 
-	m1, err := NewMinoch(manager, "A")
-	require.NoError(t, err)
+	m1 := NewMinoch(manager, "A")
 	require.NotNil(t, m1)
 
-	m2, err := NewMinoch(manager, "B")
-	require.NoError(t, err)
+	m2 := NewMinoch(manager, "B")
 	require.NotNil(t, m2)
+}
 
-	m3, err := NewMinoch(manager, "A")
-	require.Error(t, err)
-	require.Nil(t, m3)
+func TestMinoch_SameIdentifier_New(t *testing.T) {
+	defer func() {
+		r := recover()
+		require.Equal(t, r, "manager refused: identifier <A> already exists")
+	}()
 
-	m4, err := NewMinoch(manager, "")
-	require.Error(t, err)
-	require.Nil(t, m4)
+	manager := NewManager()
+
+	NewMinoch(manager, "A")
+	NewMinoch(manager, "A")
 }
 
 func TestMinoch_GetAddressFactory(t *testing.T) {
@@ -37,8 +39,7 @@ func TestMinoch_GetAddressFactory(t *testing.T) {
 func TestMinoch_GetAddress(t *testing.T) {
 	manager := NewManager()
 
-	m, err := NewMinoch(manager, "A")
-	require.NoError(t, err)
+	m := NewMinoch(manager, "A")
 
 	addr := m.GetAddress()
 	require.Equal(t, "A", addr.String())
@@ -47,8 +48,7 @@ func TestMinoch_GetAddress(t *testing.T) {
 func TestMinoch_AddFilter(t *testing.T) {
 	manager := NewManager()
 
-	m, err := NewMinoch(manager, "A")
-	require.NoError(t, err)
+	m := NewMinoch(manager, "A")
 
 	rpc, err := m.MakeRPC("test", nil, nil)
 	require.NoError(t, err)
@@ -61,8 +61,7 @@ func TestMinoch_AddFilter(t *testing.T) {
 func TestMinoch_MakeNamespace(t *testing.T) {
 	manager := NewManager()
 
-	m, err := NewMinoch(manager, "A")
-	require.NoError(t, err)
+	m := NewMinoch(manager, "A")
 
 	m2, err := m.MakeNamespace("abc")
 	require.NoError(t, err)
@@ -73,8 +72,7 @@ func TestMinoch_MakeNamespace(t *testing.T) {
 func TestMinoch_MakeRPC(t *testing.T) {
 	manager := NewManager()
 
-	m, err := NewMinoch(manager, "A")
-	require.NoError(t, err)
+	m := NewMinoch(manager, "A")
 
 	rpc, err := m.MakeRPC("rpc1", badHandler{}, fake.MessageFactory{})
 	require.NoError(t, err)

--- a/mino/minoch/mod_test.go
+++ b/mino/minoch/mod_test.go
@@ -12,23 +12,23 @@ import (
 func TestMinoch_New(t *testing.T) {
 	manager := NewManager()
 
-	m1 := NewMinoch(manager, "A")
+	m1 := MustCreate(manager, "A")
 	require.NotNil(t, m1)
 
-	m2 := NewMinoch(manager, "B")
+	m2 := MustCreate(manager, "B")
 	require.NotNil(t, m2)
 }
 
-func TestMinoch_SameIdentifier_New(t *testing.T) {
+func TestMinoch_Panic_MustCreate(t *testing.T) {
 	defer func() {
-		r := recover()
-		require.Equal(t, r, "manager refused: identifier <A> already exists")
+		r := recover().(error)
+		require.EqualError(t, r, "manager refused: identifier <A> already exists")
 	}()
 
 	manager := NewManager()
 
-	NewMinoch(manager, "A")
-	NewMinoch(manager, "A")
+	MustCreate(manager, "A")
+	MustCreate(manager, "A")
 }
 
 func TestMinoch_GetAddressFactory(t *testing.T) {
@@ -39,7 +39,7 @@ func TestMinoch_GetAddressFactory(t *testing.T) {
 func TestMinoch_GetAddress(t *testing.T) {
 	manager := NewManager()
 
-	m := NewMinoch(manager, "A")
+	m := MustCreate(manager, "A")
 
 	addr := m.GetAddress()
 	require.Equal(t, "A", addr.String())
@@ -48,7 +48,7 @@ func TestMinoch_GetAddress(t *testing.T) {
 func TestMinoch_AddFilter(t *testing.T) {
 	manager := NewManager()
 
-	m := NewMinoch(manager, "A")
+	m := MustCreate(manager, "A")
 
 	rpc, err := m.MakeRPC("test", nil, nil)
 	require.NoError(t, err)
@@ -61,7 +61,7 @@ func TestMinoch_AddFilter(t *testing.T) {
 func TestMinoch_MakeNamespace(t *testing.T) {
 	manager := NewManager()
 
-	m := NewMinoch(manager, "A")
+	m := MustCreate(manager, "A")
 
 	m2, err := m.MakeNamespace("abc")
 	require.NoError(t, err)
@@ -72,7 +72,7 @@ func TestMinoch_MakeNamespace(t *testing.T) {
 func TestMinoch_MakeRPC(t *testing.T) {
 	manager := NewManager()
 
-	m := NewMinoch(manager, "A")
+	m := MustCreate(manager, "A")
 
 	rpc, err := m.MakeRPC("rpc1", badHandler{}, fake.MessageFactory{})
 	require.NoError(t, err)

--- a/mino/minoch/rpc.go
+++ b/mino/minoch/rpc.go
@@ -1,3 +1,8 @@
+// This file contains the orchestrator side of the RPC implementation.
+//
+// Documentation Last Review: 06.10.2020
+//
+
 package minoch
 
 import (
@@ -8,7 +13,6 @@ import (
 
 	"go.dedis.ch/dela/mino"
 	"go.dedis.ch/dela/serde"
-	"go.dedis.ch/dela/serde/json"
 	"golang.org/x/xerrors"
 )
 
@@ -19,7 +23,10 @@ type Envelope struct {
 	message []byte
 }
 
-// RPC is an implementation of the mino.RPC interface.
+// RPC implements a remote procedure call that is calling its peers using the
+// channels registered by the manager.
+//
+// - implements mino.RPC
 type RPC struct {
 	manager *Manager
 	addr    mino.Address
@@ -30,14 +37,14 @@ type RPC struct {
 	filters []Filter
 }
 
-// Call sends the message to all participants and gather their reply. The
-// context is ignored in the scope of channel communication as there is no
-// blocking I/O. The response channel will receive n responses for n players and
-// be closed eventually.
+// Call implements mino.RPC. It sends the message to all participants and gather
+// their reply. The context is ignored in the scope of channel communication as
+// there is no blocking I/O. The response channel will receive n responses for n
+// players and be closed eventually.
 func (c RPC) Call(ctx context.Context,
 	req serde.Message, players mino.Players) (<-chan mino.Response, error) {
 
-	data, err := req.Serialize(json.NewContext())
+	data, err := req.Serialize(c.context)
 	if err != nil {
 		return nil, xerrors.Errorf("couldn't serialize: %v", err)
 	}
@@ -61,7 +68,7 @@ func (c RPC) Call(ctx context.Context,
 
 			from := peer.GetAddress()
 
-			msg, err := c.factory.Deserialize(json.NewContext(), data)
+			msg, err := c.factory.Deserialize(c.context, data)
 			if err != nil {
 				resp := mino.NewResponseWithError(
 					from,
@@ -130,8 +137,9 @@ func (c RPC) runFilters(req mino.Request) bool {
 	return true
 }
 
-// Stream opens a stream. The caller is responsible for cancelling the context
-// to close the stream.
+// Stream implements mino.RPC. It simulates the stream by using the orchestrator
+// as the router for all the messages. They are redirected to the channel
+// associated with the address.
 func (c RPC) Stream(ctx context.Context, memship mino.Players) (mino.Sender, mino.Receiver, error) {
 	in := make(chan Envelope, 100)
 	out := make(chan Envelope, 100)
@@ -211,12 +219,19 @@ func (c RPC) Stream(ctx context.Context, memship mino.Players) (mino.Sender, min
 	return orchSender, orchRecv, nil
 }
 
+// Sender implements the sender associated with a stream.
+//
+// - implements mino.Sender
 type sender struct {
 	addr    mino.Address
 	in      chan Envelope
 	context serde.Context
 }
 
+// Send implements mino.Sender. It sends the message to all the addresses and
+// returns a channel that will be populated with any error happening. The
+// channel is eventually closed after all participants have gotten their
+// message.
 func (s sender) Send(msg serde.Message, addrs ...mino.Address) <-chan error {
 	errs := make(chan error, int(math.Max(1, float64(len(addrs)))))
 
@@ -240,6 +255,9 @@ func (s sender) Send(msg serde.Message, addrs ...mino.Address) <-chan error {
 	return errs
 }
 
+// Receiver implements the receiver side of a stream.
+//
+// - implements mino.Receiver
 type receiver struct {
 	out     chan Envelope
 	errs    chan error
@@ -247,6 +265,9 @@ type receiver struct {
 	factory serde.Factory
 }
 
+// Recv implements mino.Receiver. It listens for messages until the context is
+// done, or a message is received. On a graceful close, the receiver will return
+// an EOF error, or the error from the context if it finishes before.
 func (r receiver) Recv(ctx context.Context) (mino.Address, serde.Message, error) {
 	select {
 	case env, ok := <-r.out:

--- a/mino/minoch/rpc.go
+++ b/mino/minoch/rpc.go
@@ -37,10 +37,10 @@ type RPC struct {
 	filters []Filter
 }
 
-// Call implements mino.RPC. It sends the message to all participants and gather
-// their reply. The context is ignored in the scope of channel communication as
-// there is no blocking I/O. The response channel will receive n responses for n
-// players and be closed eventually.
+// Call implements mino.RPC. It sends the message to all participants and
+// gathers their replies. The context is ignored in the scope of channel
+// communication as there is no blocking I/O. The response channel will receive
+// n responses for n players and be closed eventually.
 func (c RPC) Call(ctx context.Context,
 	req serde.Message, players mino.Players) (<-chan mino.Response, error) {
 

--- a/mino/minoch/rpc_test.go
+++ b/mino/minoch/rpc_test.go
@@ -14,11 +14,11 @@ import (
 func TestRPC_Call(t *testing.T) {
 	manager := NewManager()
 
-	mA := NewMinoch(manager, "A")
+	mA := MustCreate(manager, "A")
 	rpcA, err := mA.MakeRPC("test", fakeHandler{}, fake.MessageFactory{})
 	require.NoError(t, err)
 
-	mB := NewMinoch(manager, "B")
+	mB := MustCreate(manager, "B")
 	_, err = mB.MakeRPC("test", fakeHandler{}, fake.MessageFactory{})
 	require.NoError(t, err)
 
@@ -39,7 +39,7 @@ func TestRPC_Call(t *testing.T) {
 func TestRPC_Filter_Call(t *testing.T) {
 	manager := NewManager()
 
-	m := NewMinoch(manager, "A")
+	m := MustCreate(manager, "A")
 
 	rpc, err := m.MakeRPC("test", fakeHandler{}, fake.MessageFactory{})
 	require.NoError(t, err)
@@ -71,7 +71,7 @@ func TestRPC_BadContext_Call(t *testing.T) {
 func TestRPC_BadFactory_Call(t *testing.T) {
 	manager := NewManager()
 
-	m := NewMinoch(manager, "A")
+	m := MustCreate(manager, "A")
 
 	rpc, err := m.MakeRPC("test", fakeHandler{}, fake.NewBadMessageFactory())
 	require.NoError(t, err)
@@ -89,7 +89,7 @@ func TestRPC_BadFactory_Call(t *testing.T) {
 func TestRPC_UnkownPeer_Call(t *testing.T) {
 	manager := NewManager()
 
-	m := NewMinoch(manager, "A")
+	m := MustCreate(manager, "A")
 	rpc, err := m.MakeRPC("test", fakeHandler{}, fake.MessageFactory{})
 	require.NoError(t, err)
 
@@ -107,11 +107,11 @@ func TestRPC_UnkownPeer_Call(t *testing.T) {
 func TestRPC_MissingHandler_Call(t *testing.T) {
 	manager := NewManager()
 
-	mA := NewMinoch(manager, "A")
+	mA := MustCreate(manager, "A")
 	rpcA, err := mA.MakeRPC("test", fakeHandler{}, fake.MessageFactory{})
 	require.NoError(t, err)
 
-	mB := NewMinoch(manager, "B")
+	mB := MustCreate(manager, "B")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -126,11 +126,11 @@ func TestRPC_MissingHandler_Call(t *testing.T) {
 func TestRPC_BadHandler_Call(t *testing.T) {
 	manager := NewManager()
 
-	mA := NewMinoch(manager, "A")
+	mA := MustCreate(manager, "A")
 	rpcA, err := mA.MakeRPC("test", fakeHandler{}, fake.MessageFactory{})
 	require.NoError(t, err)
 
-	mB := NewMinoch(manager, "B")
+	mB := MustCreate(manager, "B")
 	_, err = mB.MakeRPC("test", badHandler{}, fake.MessageFactory{})
 	require.NoError(t, err)
 
@@ -147,7 +147,7 @@ func TestRPC_BadHandler_Call(t *testing.T) {
 func TestRPC_Stream(t *testing.T) {
 	manager := NewManager()
 
-	m := NewMinoch(manager, "A")
+	m := MustCreate(manager, "A")
 	rpc, err := m.MakeRPC("test", fakeStreamHandler{}, fake.MessageFactory{})
 	require.NoError(t, err)
 
@@ -169,7 +169,7 @@ func TestRPC_Stream(t *testing.T) {
 func TestRPC_Failures_Stream(t *testing.T) {
 	manager := NewManager()
 
-	m := NewMinoch(manager, "A")
+	m := MustCreate(manager, "A")
 
 	m.context = fake.NewBadContext()
 	rpc, err := m.MakeRPC("test", fakeBadStreamHandler{}, fake.MessageFactory{})

--- a/mino/minogrpc/rpc_test.go
+++ b/mino/minogrpc/rpc_test.go
@@ -299,7 +299,7 @@ func (badRouter) New(mino.Players) (router.RoutingTable, error) {
 	return nil, fake.GetError()
 }
 
-func (badRouter) TableOf(router.Handshake) (router.RoutingTable, error) {
+func (badRouter) GenerateTableFrom(router.Handshake) (router.RoutingTable, error) {
 	return nil, fake.GetError()
 }
 

--- a/mino/minogrpc/server.go
+++ b/mino/minogrpc/server.go
@@ -347,7 +347,7 @@ func (o *overlayServer) tableFromHeaders(h metadata.MD) (router.RoutingTable, bo
 			return nil, false, xerrors.Errorf("malformed handshake: %v", err)
 		}
 
-		table, err := o.router.TableOf(hs)
+		table, err := o.router.GenerateTableFrom(hs)
 		if err != nil {
 			return nil, false, xerrors.Errorf("invalid handshake: %v", err)
 		}

--- a/mino/minogrpc/session/mod.go
+++ b/mino/minogrpc/session/mod.go
@@ -397,7 +397,7 @@ func (s *session) setupRelay(p parent, addr mino.Address) (Relay, error) {
 		return relay, nil
 	}
 
-	hs, err := p.table.Prelude(addr).Serialize(s.context)
+	hs, err := p.table.PrepareHandshakeFor(addr).Serialize(s.context)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to serialize handshake: %v", err)
 	}

--- a/mino/minogrpc/session/mod_test.go
+++ b/mino/minogrpc/session/mod_test.go
@@ -488,7 +488,7 @@ func (t fakeTable) Make(mino.Address, []mino.Address, []byte) router.Packet {
 	return fakePkt{dest: fake.NewAddress(0), empty: t.empty}
 }
 
-func (t fakeTable) Prelude(mino.Address) router.Handshake {
+func (t fakeTable) PrepareHandshakeFor(mino.Address) router.Handshake {
 	return fakeHandshake{err: t.err}
 }
 

--- a/mino/mod.go
+++ b/mino/mod.go
@@ -1,6 +1,12 @@
-// Package mino provides an abstraction for an application layer. It offers a
-// Minimalistic Overlay Network (MINO) to communicate between participants of
-// a distributed system.
+// Package mino defines a minimalist network overlay to communicate between a
+// set of participants.
+//
+// The overlay provides two primitives to send messages: Call that will directly
+// contact the addresses and Stream that will build a network and distribute the
+// load to forward the messages.
+//
+// Documentation Last Review: 07.10.2020
+//
 package mino
 
 import (
@@ -11,13 +17,45 @@ import (
 	"go.dedis.ch/dela/serde"
 )
 
+// Mino is an abstraction of a overlay network. It provides primitives to send
+// messages to a set of participants.
+//
+// It uses namespaces to separate the different RPCs of multiple services in a
+// URI-like manner (i.e. /my/awesome/rpc has _my_ and _awesome_ namespaces).
+type Mino interface {
+	// GetAddressFactory returns the factory for addresses.
+	GetAddressFactory() AddressFactory
+
+	// Address returns the address that other participants should use to contact
+	// this instance.
+	GetAddress() Address
+
+	// MakeNamespace returns an instance restricted to the namespace.
+	MakeNamespace(namespace string) (Mino, error)
+
+	// MakeRPC creates an RPC that can send to and receive from a unique URI
+	// which is computed with URI = (namespace || name). The namespace is known
+	// by the mino instance.
+	MakeRPC(name string, h Handler, f serde.Factory) (RPC, error)
+}
+
 // Address is a representation of a node's address.
 type Address interface {
 	encoding.TextMarshaler
 
+	// Equal returns true when both addresses are similar.
 	Equal(other Address) bool
 
+	// String returns a string representation of the address.
 	String() string
+}
+
+// AddressFactory is the factory to decode addresses.
+type AddressFactory interface {
+	serde.Factory
+
+	// FromText returns the address of the text.
+	FromText(text []byte) Address
 }
 
 // AddressIterator is an iterator over the list of addresses of a membership.
@@ -48,19 +86,18 @@ type Players interface {
 	Len() int
 }
 
-// Sender is an interface to provide primitives to send messages to recipients.
-type Sender interface {
-	// Send sends the message to all the addresses. It returns a channel that
-	// will be populated with errors coming from the network layer if the
-	// message cannot be sent. The channel must be closed after the message has
-	// been/failed to be sent.
-	Send(msg serde.Message, addrs ...Address) <-chan error
-}
+// RPC is an abstraction of a distributed Remote Procedure Call.
+type RPC interface {
+	// Call is a basic request to one or multiple distant peers. It directly
+	// contacts all the players and thus expect a reasonable number of peers.
+	//
+	// The response channel must be closed after every request ended in a
+	// result, either a reply or an error.
+	Call(ctx context.Context, req serde.Message, players Players) (<-chan Response, error)
 
-// Receiver is an interface to provide primitives to receive messages from
-// recipients.
-type Receiver interface {
-	Recv(context.Context) (Address, serde.Message, error)
+	// Stream is a persistent request that will be closed only when the
+	// orchestrator is done or an error occured.
+	Stream(ctx context.Context, players Players) (Sender, Receiver, error)
 }
 
 // Request is a wrapper around the context of a message received from a player
@@ -74,9 +111,9 @@ type Request struct {
 	Message serde.Message
 }
 
-// Response is a interface that Mino implementations should comply with. The
-// response can either contain a message, or an error if something wrong
-// happened.
+// Response represents the response of a distributed RPC. It provides the
+// address of the original sender and the reply, or an error if something went
+// wrong upfront.
 type Response interface {
 	// GetFrom returns the address of the source of the reply.
 	GetFrom() Address
@@ -86,19 +123,23 @@ type Response interface {
 	GetMessageOrError() (serde.Message, error)
 }
 
-// RPC is a representation of a remote procedure call that can call a single
-// distant procedure or multiple.
-type RPC interface {
-	// Call is a basic request to one or multiple distant peers. It directly
-	// contacts all the players and thus expect a reasonable number of peers.
-	//
-	// The response channel must be closed after every request ended in a
-	// result, either a reply or an error.
-	Call(ctx context.Context, req serde.Message, players Players) (<-chan Response, error)
+// Sender is an abstraction to send messages to a stream in the context of a
+// distributed RPC.
+type Sender interface {
+	// Send sends the message to all the addresses. It returns a channel that
+	// will be populated with errors coming from the network layer if the
+	// message cannot be sent. The channel must be closed after the message has
+	// been/failed to be sent.
+	Send(msg serde.Message, addrs ...Address) <-chan error
+}
 
-	// Stream is a persistent request that will be closed only when the
-	// orchestrator is done or an error occured.
-	Stream(ctx context.Context, players Players) (Sender, Receiver, error)
+// Receiver is an abstraction to receive messages from a stream in the context
+// of a distributed RPC.
+type Receiver interface {
+	// Recv waits for a message to send received from the stream. It returns the
+	// address of the original sender and the message, or a message if the
+	// stream is closed or the context is done.
+	Recv(context.Context) (Address, serde.Message, error)
 }
 
 // Handler is the interface to implement to create a public endpoint.
@@ -124,29 +165,4 @@ func (h UnsupportedHandler) Process(req Request) (serde.Message, error) {
 // Stream is the default implementation for a handler. It will return an error.
 func (h UnsupportedHandler) Stream(in Sender, out Receiver) error {
 	return errors.New("stream is not supported")
-}
-
-// AddressFactory is the factory to decode addresses.
-type AddressFactory interface {
-	serde.Factory
-
-	FromText(text []byte) Address
-}
-
-// Mino is a representation of a overlay network that allows the creation
-// of namespaces for internal protocols and associate handlers to it.
-type Mino interface {
-	GetAddressFactory() AddressFactory
-
-	// Address returns the address that other participants should use to contact
-	// this instance.
-	GetAddress() Address
-
-	// MakeNamespace returns an instance restricted to the namespace.
-	MakeNamespace(namespace string) (Mino, error)
-
-	// MakeRPC creates an RPC that can send to and receive from a unique URI
-	// which is computed with URI = (namespace || name). The namespace is known
-	// by the mino instance.
-	MakeRPC(name string, h Handler, f serde.Factory) (RPC, error)
 }

--- a/mino/mod.go
+++ b/mino/mod.go
@@ -89,14 +89,14 @@ type Players interface {
 // RPC is an abstraction of a distributed Remote Procedure Call.
 type RPC interface {
 	// Call is a basic request to one or multiple distant peers. It directly
-	// contacts all the players and thus expect a reasonable number of peers.
+	// contacts all the players and thus expects a reasonable number of peers.
 	//
-	// The response channel must be closed after every request ended in a
-	// result, either a reply or an error.
+	// The response channel must be closed once the request ends in a result,
+	// either a reply or an error.
 	Call(ctx context.Context, req serde.Message, players Players) (<-chan Response, error)
 
 	// Stream is a persistent request that will be closed only when the
-	// orchestrator is done or an error occured, or the context is done.
+	// orchestrator is done or an error has occured, or the context is done.
 	Stream(ctx context.Context, players Players) (Sender, Receiver, error)
 }
 
@@ -129,7 +129,7 @@ type Sender interface {
 	// Send sends the message to all the addresses. It returns a channel that
 	// will be populated with errors coming from the network layer if the
 	// message cannot be sent. The channel must be closed after the message has
-	// been/failed to be sent.
+	// been sent or failed to be sent.
 	Send(msg serde.Message, addrs ...Address) <-chan error
 }
 

--- a/mino/mod.go
+++ b/mino/mod.go
@@ -96,7 +96,7 @@ type RPC interface {
 	Call(ctx context.Context, req serde.Message, players Players) (<-chan Response, error)
 
 	// Stream is a persistent request that will be closed only when the
-	// orchestrator is done or an error occured.
+	// orchestrator is done or an error occured, or the context is done.
 	Stream(ctx context.Context, players Players) (Sender, Receiver, error)
 }
 

--- a/mino/option.go
+++ b/mino/option.go
@@ -1,3 +1,7 @@
+//
+// Documentation Last Review: 07.10.2020
+//
+
 package mino
 
 import (

--- a/mino/response.go
+++ b/mino/response.go
@@ -1,3 +1,7 @@
+//
+// Documentation Last Review: 07.10.2020
+//
+
 package mino
 
 import "go.dedis.ch/dela/serde"

--- a/mino/router/mod.go
+++ b/mino/router/mod.go
@@ -1,5 +1,8 @@
 // Package router defines the primitives to route a packet among a set of
 // participants.
+//
+// Documentation Last Review: 06.10.2020
+//
 package router
 
 import (
@@ -32,6 +35,8 @@ type Packet interface {
 type PacketFactory interface {
 	serde.Factory
 
+	// PacketOf returns the packet for the data if appropriate, otherwise an
+	// error.
 	PacketOf(serde.Context, []byte) (Packet, error)
 }
 
@@ -45,6 +50,8 @@ type Handshake interface {
 type HandshakeFactory interface {
 	serde.Factory
 
+	// HandshakeOf returns the handshake of the data if appropriate, otherwise
+	// an error.
 	HandshakeOf(serde.Context, []byte) (Handshake, error)
 }
 
@@ -53,10 +60,13 @@ type HandshakeFactory interface {
 // is not handled by the router. For that matter, the Packet.Slice function can
 // be used to handle special cases with that address.
 type Router interface {
+	// GetPacketFactory returns the packet factory.
 	GetPacketFactory() PacketFactory
 
+	// GetHandshakeFactory returns the handshake factory.
 	GetHandshakeFactory() HandshakeFactory
 
+	// New creates a new routing table that will forward packets to the players.
 	New(mino.Players) (RoutingTable, error)
 
 	// TableOf returns the routing table associated to the handshake. A node

--- a/mino/router/mod.go
+++ b/mino/router/mod.go
@@ -69,9 +69,9 @@ type Router interface {
 	// New creates a new routing table that will forward packets to the players.
 	New(mino.Players) (RoutingTable, error)
 
-	// TableOf returns the routing table associated to the handshake. A node
-	// should be able to route any incoming packet after receiving one.
-	TableOf(Handshake) (RoutingTable, error)
+	// GenerateTableFrom returns the routing table associated to the handshake.
+	// A node should be able to route any incoming packet after receiving one.
+	GenerateTableFrom(Handshake) (RoutingTable, error)
 }
 
 // Routes is a set of relay addresses where to send the packet.
@@ -92,9 +92,9 @@ type RoutingTable interface {
 	// payload.
 	Make(src mino.Address, to []mino.Address, msg []byte) Packet
 
-	// Prelude is called before a relay is opened to generate the handshake that
-	// will be sent.
-	Prelude(mino.Address) Handshake
+	// PrepareHandshakeFor is called before a relay is opened to generate the
+	// handshake that will be sent.
+	PrepareHandshakeFor(mino.Address) Handshake
 
 	// Forward takes the destination address, unmarshal the packet, and, based
 	// on its content, return a map of packets, where each element of the map

--- a/mino/router/tree/example_test.go
+++ b/mino/router/tree/example_test.go
@@ -1,0 +1,65 @@
+package tree
+
+import (
+	"fmt"
+
+	"go.dedis.ch/dela/mino"
+	"go.dedis.ch/dela/mino/minogrpc/session"
+)
+
+func ExampleRouter_New() {
+	router := NewRouter(session.AddressFactory{})
+
+	addrA := session.NewAddress("127.0.0.1:2000")
+	addrB := session.NewAddress("127.0.0.1:3000")
+
+	players := mino.NewAddresses(addrA, addrB)
+
+	table, err := router.New(players)
+	if err != nil {
+		panic("routing table failed: " + err.Error())
+	}
+
+	routes, voids := table.Forward(table.Make(addrA, []mino.Address{addrB}, []byte{}))
+	fmt.Println(voids)
+
+	for to := range routes {
+		fmt.Println(to)
+	}
+
+	// Output: map[]
+	// 127.0.0.1:3000
+}
+
+func ExampleTable_Prelude() {
+	routerA := NewRouter(session.AddressFactory{})
+
+	addrA := session.NewAddress("127.0.0.1:2000")
+	addrB := session.NewAddress("127.0.0.1:3000")
+
+	players := mino.NewAddresses(addrA, addrB)
+
+	table, err := routerA.New(players)
+	if err != nil {
+		panic("routing table failed: " + err.Error())
+	}
+
+	handshake := table.Prelude(addrB)
+
+	// Send the handshake to the address B..
+
+	routerB := NewRouter(session.AddressFactory{})
+
+	tableB, err := routerB.TableOf(handshake)
+	if err != nil {
+		panic("malformed handshake: " + err.Error())
+	}
+
+	packet := tableB.Make(addrB, []mino.Address{addrA}, []byte{})
+
+	fmt.Println(packet.GetSource())
+	fmt.Println(packet.GetDestination())
+
+	// Output: 127.0.0.1:3000
+	// [127.0.0.1:2000]
+}

--- a/mino/router/tree/example_test.go
+++ b/mino/router/tree/example_test.go
@@ -31,7 +31,7 @@ func ExampleRouter_New() {
 	// 127.0.0.1:3000
 }
 
-func ExampleTable_Prelude() {
+func ExampleTable_PrepareHandshakeFor() {
 	routerA := NewRouter(session.AddressFactory{})
 
 	addrA := session.NewAddress("127.0.0.1:2000")
@@ -44,13 +44,13 @@ func ExampleTable_Prelude() {
 		panic("routing table failed: " + err.Error())
 	}
 
-	handshake := table.Prelude(addrB)
+	handshake := table.PrepareHandshakeFor(addrB)
 
 	// Send the handshake to the address B..
 
 	routerB := NewRouter(session.AddressFactory{})
 
-	tableB, err := routerB.TableOf(handshake)
+	tableB, err := routerB.GenerateTableFrom(handshake)
 	if err != nil {
 		panic("malformed handshake: " + err.Error())
 	}

--- a/mino/router/tree/mod.go
+++ b/mino/router/tree/mod.go
@@ -69,9 +69,9 @@ func (r Router) New(players mino.Players) (router.RoutingTable, error) {
 	return NewTable(r.maxHeight, addrs), nil
 }
 
-// TableOf implements router.Router. It creates the routing table associated
-// with the handshake that can contain some parameter.
-func (r Router) TableOf(h router.Handshake) (router.RoutingTable, error) {
+// GenerateTableFrom implements router.Router. It creates the routing table
+// associated with the handshake that can contain some parameter.
+func (r Router) GenerateTableFrom(h router.Handshake) (router.RoutingTable, error) {
 	treeH := h.(types.Handshake)
 
 	return NewTable(treeH.GetHeight(), treeH.GetAddresses()), nil
@@ -98,10 +98,10 @@ func (t Table) Make(src mino.Address, to []mino.Address, msg []byte) router.Pack
 	return types.NewPacket(src, msg, to...)
 }
 
-// Prelude implements router.RoutingTable. It creates a handshake message that
-// should be sent to the distant peer when opening a relay to it. The peer will
-// then generate its own routing table based on the handshake.
-func (t Table) Prelude(to mino.Address) router.Handshake {
+// PrepareHandshakeFor implements router.RoutingTable. It creates a handshake
+// message that should be sent to the distant peer when opening a relay to it.
+// The peer will then generate its own routing table based on the handshake.
+func (t Table) PrepareHandshakeFor(to mino.Address) router.Handshake {
 	newHeight := t.tree.GetMaxHeight() - 1
 
 	return types.NewHandshake(newHeight, t.tree.GetChildren(to)...)

--- a/mino/router/tree/mod_test.go
+++ b/mino/router/tree/mod_test.go
@@ -37,11 +37,11 @@ func TestRouter_New(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestRouter_TableOf(t *testing.T) {
+func TestRouter_GenerateTableFrom(t *testing.T) {
 	router := NewRouter(fake.AddressFactory{})
 
 	hs := types.NewHandshake(3, makeAddrs(5)...)
-	table, err := router.TableOf(hs)
+	table, err := router.GenerateTableFrom(hs)
 	require.NoError(t, err)
 	require.NotNil(t, table)
 }
@@ -56,10 +56,10 @@ func TestTable_Make(t *testing.T) {
 	require.Equal(t, []byte{1, 2, 3}, pkt.GetMessage())
 }
 
-func TestTable_Prelude(t *testing.T) {
+func TestTable_PrepareHandshakeFor(t *testing.T) {
 	table := NewTable(3, makeAddrs(5))
 
-	hs := table.Prelude(fake.NewAddress(1))
+	hs := table.PrepareHandshakeFor(fake.NewAddress(1))
 	require.Equal(t, 2, hs.(types.Handshake).GetHeight())
 }
 

--- a/mino/router/tree/tree.go
+++ b/mino/router/tree/tree.go
@@ -1,3 +1,7 @@
+//
+// Documentation Last Review: 06.10.2020
+//
+
 package tree
 
 import (
@@ -62,7 +66,7 @@ func (c Branches) Search(to mino.Address) mino.Address {
 	return nil
 }
 
-// DynamicTree is a tree that will optimistically build the tree according on
+// DynamicTree is a tree that will optimistically build the tree according to
 // route requests. It will adjust the branches and their children when
 // necessary.
 //

--- a/mino/router/tree/types/handshake.go
+++ b/mino/router/tree/types/handshake.go
@@ -1,3 +1,9 @@
+// The file contains the implementation of a handshake message that is sent to
+// create the routing table.
+//
+// Documentation Last Review: 06.10.2020
+//
+
 package types
 
 import (

--- a/mino/router/tree/types/mod.go
+++ b/mino/router/tree/types/mod.go
@@ -1,3 +1,11 @@
+// Package types implements the packet and handshake messages for the tree
+// routing algorithm.
+//
+// The messages have been implemented in this isolated package so that it does
+// not create cycle imports when importing the serde formats.
+//
+// Documentation Last Review: 06.10.2020
+//
 package types
 
 import "go.dedis.ch/dela/serde"

--- a/mino/router/tree/types/packet.go
+++ b/mino/router/tree/types/packet.go
@@ -1,3 +1,8 @@
+// This file contains the implementation of the packet message.
+//
+// Documentation Last Review: 06.10.2020
+//
+
 package types
 
 import (
@@ -43,10 +48,11 @@ func (p *Packet) GetDestination() []mino.Address {
 // GetMessage implements router.Packet. It returns the byte buffer of the
 // message.
 func (p *Packet) GetMessage() []byte {
-	return p.msg
+	return append([]byte{}, p.msg...)
 }
 
-// Add appends the address to the destination list.
+// Add appends the address to the destination list, only if it does not exist
+// already.
 func (p *Packet) Add(to mino.Address) {
 	for _, addr := range p.dest {
 		if addr.Equal(to) {


### PR DESCRIPTION
This updates the documentation of the mino packages minus minogrpc and proxy.

Also: minoch new function does not return an error but panic.