### PR TITLE
Make: add a command to update the doc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,3 +17,12 @@ vet:
 # pushing code
 check: lint vet
 	go test ./...
+
+# https://pkg.go.dev/go.dedis.ch/dela needs to be updated on the Go proxy side
+# to get the latest master. This command refreshes the proxy with the latest
+# commit on the upstream master branch.
+# Note: CURL must be installed
+pushdoc:
+	@echo "Requesting the proxy..."
+	@curl "https://proxy.golang.org/go.dedis.ch/dela/@v/$(shell git log origin/master -1 --format=format:%H).info"
+	@echo "\nDone."


### PR DESCRIPTION
The command refreshes the documentation on pkg.go.dev by forcing the proxy to get the latest master commit.