### PR TITLE
Mino: namespace refactoring

### DIFF
--- a/core/ordering/cosipbft/blocksync/default.go
+++ b/core/ordering/cosipbft/blocksync/default.go
@@ -44,7 +44,7 @@ type SyncParam struct {
 }
 
 // NewSynchronizer creates a new block synchronizer.
-func NewSynchronizer(param SyncParam) (Synchronizer, error) {
+func NewSynchronizer(param SyncParam) Synchronizer {
 	latest := param.Blocks.Len()
 
 	logger := dela.Logger.With().Str("addr", param.Mino.GetAddress().String()).Logger()
@@ -61,21 +61,16 @@ func NewSynchronizer(param SyncParam) (Synchronizer, error) {
 
 	fac := types.NewMessageFactory(param.LinkFactory, param.ChainFactory)
 
-	rpc, err := param.Mino.MakeRPC("blocksync", h, fac)
-	if err != nil {
-		return nil, xerrors.Errorf("rpc creation failed: %v", err)
-	}
-
 	s := defaultSync{
 		logger:      logger,
-		rpc:         rpc,
+		rpc:         mino.MustCreateRPC(param.Mino, "blocksync", h, fac),
 		pbftsm:      param.PBFT,
 		blocks:      param.Blocks,
 		latest:      &latest,
 		catchUpLock: h.catchUpLock,
 	}
 
-	return s, nil
+	return s
 }
 
 // GetLatest implements blocksync.Synchronizer. It returns the latest index

--- a/core/ordering/cosipbft/blocksync/default_test.go
+++ b/core/ordering/cosipbft/blocksync/default_test.go
@@ -77,16 +77,6 @@ func TestDefaultSync_Basic(t *testing.T) {
 	}
 }
 
-func TestDefaultSync_New(t *testing.T) {
-	param := SyncParam{
-		Mino:   fake.NewBadMino(),
-		Blocks: blockstore.NewInMemory(),
-	}
-
-	_, err := NewSynchronizer(param)
-	require.EqualError(t, err, fake.Err("rpc creation failed"))
-}
-
 func TestDefaultSync_GetLatest(t *testing.T) {
 	latest := uint64(5)
 
@@ -302,10 +292,7 @@ func makeNodes(t *testing.T, n int) ([]defaultSync, otypes.Genesis, mino.Players
 			VerifierFactory: fake.VerifierFactory{},
 		}
 
-		sync, err := NewSynchronizer(param)
-		require.NoError(t, err)
-
-		syncs[i] = sync.(defaultSync)
+		syncs[i] = NewSynchronizer(param).(defaultSync)
 	}
 
 	return syncs, genesis, mino.NewAddresses(addrs...)

--- a/core/ordering/cosipbft/controller/mod.go
+++ b/core/ordering/cosipbft/controller/mod.go
@@ -103,7 +103,7 @@ func (m minimal) OnStart(flags cli.Flags, inj node.Injector) error {
 		return xerrors.Errorf("signer: %v", err)
 	}
 
-	cosi := threshold.NewThreshold(onet, signer)
+	cosi := threshold.NewThreshold(onet.WithSegment("cosi"), signer)
 	cosi.SetThreshold(threshold.ByzantineThreshold)
 
 	exec := native.NewExecution()
@@ -115,7 +115,7 @@ func (m minimal) OnStart(flags cli.Flags, inj node.Injector) error {
 	txFac := signed.NewTransactionFactory()
 	vs := simple.NewService(exec, txFac)
 
-	pool, err := poolimpl.NewPool(gossip.NewFlat(onet, txFac))
+	pool, err := poolimpl.NewPool(gossip.NewFlat(onet.WithSegment("pool"), txFac))
 	if err != nil {
 		return xerrors.Errorf("pool: %v", err)
 	}

--- a/core/ordering/cosipbft/controller/mod_test.go
+++ b/core/ordering/cosipbft/controller/mod_test.go
@@ -64,20 +64,6 @@ func TestMinimal_FailLoadKey_OnStart(t *testing.T) {
 		fake.Err("signer: while loading: generator failed: failed to marshal signer"))
 }
 
-func TestMinimal_FailCreatePool_OnStart(t *testing.T) {
-	flags, _, clean := makeFlags(t)
-	defer clean()
-
-	m := NewMinimal().(minimal)
-
-	inj := node.NewInjector()
-	inj.Inject(fake.NewBadMino())
-
-	err := m.OnStart(flags, inj)
-	require.EqualError(t, err,
-		fake.Err("pool: failed to listen: couldn't create the rpc"))
-}
-
 func TestMinimal_MissingDB_OnStart(t *testing.T) {
 	flags, _, clean := makeFlags(t)
 	defer clean()

--- a/core/ordering/cosipbft/mod.go
+++ b/core/ordering/cosipbft/mod.go
@@ -166,10 +166,7 @@ func NewService(param ServiceParam, opts ...ServiceOption) (*Service, error) {
 		VerifierFactory: param.Cosi.GetVerifierFactory(),
 	}
 
-	blocksync, err := blocksync.NewSynchronizer(syncparam)
-	if err != nil {
-		return nil, xerrors.Errorf("creating sync failed: %v", err)
-	}
+	blocksync := blocksync.NewSynchronizer(syncparam)
 
 	proc.sync = blocksync
 
@@ -183,11 +180,6 @@ func NewService(param ServiceParam, opts ...ServiceOption) (*Service, error) {
 
 	proc.MessageFactory = fac
 
-	rpc, err := param.Mino.MakeRPC(rpcName, proc, fac)
-	if err != nil {
-		return nil, xerrors.Errorf("creating rpc failed: %v", err)
-	}
-
 	actor, err := param.Cosi.Listen(proc)
 	if err != nil {
 		return nil, xerrors.Errorf("creating cosi failed: %v", err)
@@ -196,7 +188,7 @@ func NewService(param ServiceParam, opts ...ServiceOption) (*Service, error) {
 	s := &Service{
 		processor:                proc,
 		me:                       param.Mino.GetAddress(),
-		rpc:                      rpc,
+		rpc:                      mino.MustCreateRPC(param.Mino, rpcName, proc, fac),
 		actor:                    actor,
 		val:                      param.Validation,
 		verifierFac:              param.Cosi.GetVerifierFactory(),

--- a/core/ordering/cosipbft/mod_test.go
+++ b/core/ordering/cosipbft/mod_test.go
@@ -194,11 +194,6 @@ func TestService_New(t *testing.T) {
 
 	<-srvc.closed
 
-	param.Mino = fake.NewBadMino()
-	_, err = NewService(param)
-	require.EqualError(t, err, fake.Err("creating sync failed: rpc creation failed"))
-
-	param.Mino = fake.Mino{}
 	param.Cosi = badCosi{}
 	_, err = NewService(param)
 	require.EqualError(t, err, fake.Err("creating cosi failed"))

--- a/cosi/flatcosi/mod.go
+++ b/cosi/flatcosi/mod.go
@@ -81,12 +81,7 @@ func (flat *Flat) Listen(r cosi.Reactor) (cosi.Actor, error) {
 
 	factory := cosi.NewMessageFactory(r, flat.signer.GetSignatureFactory())
 
-	rpc, err := flat.mino.MakeRPC(rpcName, newHandler(flat.signer, r), factory)
-	if err != nil {
-		return nil, xerrors.Errorf("couldn't make the rpc: %v", err)
-	}
-
-	actor.rpc = rpc
+	actor.rpc = mino.MustCreateRPC(flat.mino, rpcName, newHandler(flat.signer, r), factory)
 
 	return actor, nil
 }

--- a/cosi/flatcosi/mod_test.go
+++ b/cosi/flatcosi/mod_test.go
@@ -41,13 +41,6 @@ func TestFlat_Listen(t *testing.T) {
 	require.NotNil(t, actor.rpc)
 }
 
-func TestFlat_FailRPC_Listen(t *testing.T) {
-	flat := NewFlat(fake.NewBadMino(), bls.NewSigner())
-
-	_, err := flat.Listen(fakeReactor{})
-	require.EqualError(t, err, fake.Err("couldn't make the rpc"))
-}
-
 func TestActor_Sign(t *testing.T) {
 	message := fake.Message{}
 	ca := fake.NewAuthority(1, fake.NewSigner)

--- a/cosi/threshold/mod.go
+++ b/cosi/threshold/mod.go
@@ -17,7 +17,6 @@ import (
 	"go.dedis.ch/dela/cosi/threshold/types"
 	"go.dedis.ch/dela/crypto"
 	"go.dedis.ch/dela/mino"
-	"golang.org/x/xerrors"
 )
 
 func defaultThreshold(n int) int {
@@ -109,15 +108,10 @@ func (c *Threshold) SetThreshold(fn cosi.Threshold) {
 func (c *Threshold) Listen(r cosi.Reactor) (cosi.Actor, error) {
 	factory := cosi.NewMessageFactory(r, c.signer.GetSignatureFactory())
 
-	rpc, err := c.mino.MakeRPC("cosi", newHandler(c, r), factory)
-	if err != nil {
-		return nil, xerrors.Errorf("couldn't make rpc: %v", err)
-	}
-
 	actor := thresholdActor{
 		Threshold: c,
 		me:        c.mino.GetAddress(),
-		rpc:       rpc,
+		rpc:       mino.MustCreateRPC(c.mino, "cosi", newHandler(c, r), factory),
 		reactor:   r,
 	}
 

--- a/cosi/threshold/mod_test.go
+++ b/cosi/threshold/mod_test.go
@@ -94,10 +94,6 @@ func TestThreshold_Listen(t *testing.T) {
 	actor, err := c.Listen(fakeReactor{})
 	require.NoError(t, err)
 	require.NotNil(t, actor)
-
-	c.mino = fake.NewBadMino()
-	_, err = c.Listen(fakeReactor{})
-	require.EqualError(t, err, fake.Err("couldn't make rpc"))
 }
 
 // -----------------------------------------------------------------------------

--- a/dkg/pedersen/mod.go
+++ b/dkg/pedersen/mod.go
@@ -54,13 +54,8 @@ func NewPedersen(m mino.Mino) (*Pedersen, kyber.Point) {
 func (s *Pedersen) Listen() (dkg.Actor, error) {
 	h := NewHandler(s.privKey, s.mino.GetAddress())
 
-	rpc, err := s.mino.MakeRPC("dkg", h, s.factory)
-	if err != nil {
-		return nil, xerrors.Errorf("failed to create RPC: %v", err)
-	}
-
 	a := &Actor{
-		rpc:      rpc,
+		rpc:      mino.MustCreateRPC(s.mino, "dkg", h, s.factory),
 		factory:  s.factory,
 		startRes: h.startRes,
 	}

--- a/dkg/pedersen/mod_test.go
+++ b/dkg/pedersen/mod_test.go
@@ -16,11 +16,8 @@ import (
 )
 
 func TestPedersen_Listen(t *testing.T) {
-	pedersen, _ := NewPedersen(fake.NewBadMino())
-	_, err := pedersen.Listen()
-	require.EqualError(t, err, fake.Err("failed to create RPC"))
+	pedersen, _ := NewPedersen(fake.Mino{})
 
-	pedersen, _ = NewPedersen(fake.Mino{})
 	actor, err := pedersen.Listen()
 	require.NoError(t, err)
 

--- a/internal/testing/fake/mino.go
+++ b/internal/testing/fake/mino.go
@@ -454,9 +454,14 @@ func (m Mino) GetAddressFactory() mino.AddressFactory {
 	return AddressFactory{}
 }
 
-// MakeRPC implements mino.Mino.
-func (m Mino) MakeRPC(string, mino.Handler, serde.Factory) (mino.RPC, error) {
-	return NewRPC(), m.err
+// WithSegment implements mino.Mino.
+func (m Mino) WithSegment(segment string) mino.Mino {
+	return m
+}
+
+// CreateRPC implements mino.Mino.
+func (m Mino) CreateRPC(string, mino.Handler, serde.Factory) (mino.RPC, error) {
+	return NewRPC(), nil
 }
 
 // MakeCertificate generates a valid certificate for the localhost address and

--- a/mino/gossip/flat.go
+++ b/mino/gossip/flat.go
@@ -45,14 +45,9 @@ func NewFlat(m mino.Mino, f serde.Factory) *Flat {
 func (flat *Flat) Listen() (Actor, error) {
 	h := handler{Flat: flat}
 
-	rpc, err := flat.mino.MakeRPC("flatgossip", h, flat.rumorFactory)
-	if err != nil {
-		return nil, xerrors.Errorf("couldn't create the rpc: %v", err)
-	}
-
 	actor := &flatActor{
 		logger: dela.Logger.With().Str("addr", flat.mino.GetAddress().String()).Logger(),
-		rpc:    rpc,
+		rpc:    mino.MustCreateRPC(flat.mino, "flatgossip", h, flat.rumorFactory),
 	}
 
 	return actor, nil

--- a/mino/gossip/flat_test.go
+++ b/mino/gossip/flat_test.go
@@ -17,10 +17,6 @@ func TestFlat_Listen(t *testing.T) {
 	actor, err := gossiper.Listen()
 	require.NoError(t, err)
 	require.NotNil(t, actor)
-
-	gossiper.mino = fake.NewBadMino()
-	_, err = gossiper.Listen()
-	require.EqualError(t, err, fake.Err("couldn't create the rpc"))
 }
 
 func TestFlat_Rumors(t *testing.T) {

--- a/mino/minoch/example_test.go
+++ b/mino/minoch/example_test.go
@@ -11,30 +11,13 @@ import (
 func ExampleRPC_Call() {
 	manager := NewManager()
 
-	minoA := MustCreate(manager, "A")
-	minoB := MustCreate(manager, "B")
+	minoA := MustCreate(manager, "A").WithSegment("example")
+	minoB := MustCreate(manager, "B").WithSegment("example")
+
+	rpcA := mino.MustCreateRPC(minoA, "hello", exampleHandler{}, exampleFactory{})
+	mino.MustCreateRPC(minoB, "hello", exampleHandler{}, exampleFactory{})
 
 	roster := mino.NewAddresses(minoA.GetAddress(), minoB.GetAddress())
-
-	nsA, err := minoA.MakeNamespace("example")
-	if err != nil {
-		panic("namespace failed: " + err.Error())
-	}
-
-	rpcA, err := nsA.MakeRPC("hello", exampleHandler{}, exampleFactory{})
-	if err != nil {
-		panic("rpc failed: " + err.Error())
-	}
-
-	nsB, err := minoB.MakeNamespace("example")
-	if err != nil {
-		panic("namespace failed: " + err.Error())
-	}
-
-	_, err = nsB.MakeRPC("hello", exampleHandler{}, exampleFactory{})
-	if err != nil {
-		panic("rpc failed: " + err.Error())
-	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/mino/minoch/mod_test.go
+++ b/mino/minoch/mod_test.go
@@ -50,33 +50,34 @@ func TestMinoch_AddFilter(t *testing.T) {
 
 	m := MustCreate(manager, "A")
 
-	rpc, err := m.MakeRPC("test", nil, nil)
-	require.NoError(t, err)
+	rpc := mino.MustCreateRPC(m, "test", nil, nil)
 
 	m.AddFilter(func(m mino.Request) bool { return true })
 	require.Len(t, m.filters, 1)
 	require.Len(t, rpc.(*RPC).filters, 1)
 }
 
-func TestMinoch_MakeNamespace(t *testing.T) {
+func TestMinoch_WithSegment(t *testing.T) {
 	manager := NewManager()
 
 	m := MustCreate(manager, "A")
 
-	m2, err := m.MakeNamespace("abc")
-	require.NoError(t, err)
+	m2 := m.WithSegment("abc")
 	require.Equal(t, m.identifier, m2.(*Minoch).identifier)
 	require.Equal(t, "/abc", m2.(*Minoch).path)
 }
 
-func TestMinoch_MakeRPC(t *testing.T) {
+func TestMinoch_CreateRPC(t *testing.T) {
 	manager := NewManager()
 
 	m := MustCreate(manager, "A")
 
-	rpc, err := m.MakeRPC("rpc1", badHandler{}, fake.MessageFactory{})
+	rpc, err := m.CreateRPC("rpc_name", fakeHandler{}, fake.MessageFactory{})
 	require.NoError(t, err)
 	require.NotNil(t, rpc)
+
+	_, err = m.CreateRPC("rpc_name", fakeHandler{}, fake.MessageFactory{})
+	require.EqualError(t, err, "rpc '/rpc_name' already exists")
 }
 
 type badHandler struct {

--- a/mino/minoch/rpc_test.go
+++ b/mino/minoch/rpc_test.go
@@ -15,12 +15,10 @@ func TestRPC_Call(t *testing.T) {
 	manager := NewManager()
 
 	mA := MustCreate(manager, "A")
-	rpcA, err := mA.MakeRPC("test", fakeHandler{}, fake.MessageFactory{})
-	require.NoError(t, err)
+	rpcA := mino.MustCreateRPC(mA, "test", fakeHandler{}, fake.MessageFactory{})
 
 	mB := MustCreate(manager, "B")
-	_, err = mB.MakeRPC("test", fakeHandler{}, fake.MessageFactory{})
-	require.NoError(t, err)
+	mino.MustCreateRPC(mB, "test", fakeHandler{}, fake.MessageFactory{})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -41,8 +39,7 @@ func TestRPC_Filter_Call(t *testing.T) {
 
 	m := MustCreate(manager, "A")
 
-	rpc, err := m.MakeRPC("test", fakeHandler{}, fake.MessageFactory{})
-	require.NoError(t, err)
+	rpc := mino.MustCreateRPC(m, "test", fakeHandler{}, fake.MessageFactory{})
 
 	m.AddFilter(func(m mino.Request) bool { return false })
 
@@ -73,8 +70,7 @@ func TestRPC_BadFactory_Call(t *testing.T) {
 
 	m := MustCreate(manager, "A")
 
-	rpc, err := m.MakeRPC("test", fakeHandler{}, fake.NewBadMessageFactory())
-	require.NoError(t, err)
+	rpc := mino.MustCreateRPC(m, "test", fakeHandler{}, fake.NewBadMessageFactory())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -90,8 +86,7 @@ func TestRPC_UnkownPeer_Call(t *testing.T) {
 	manager := NewManager()
 
 	m := MustCreate(manager, "A")
-	rpc, err := m.MakeRPC("test", fakeHandler{}, fake.MessageFactory{})
-	require.NoError(t, err)
+	rpc := mino.MustCreateRPC(m, "test", fakeHandler{}, fake.MessageFactory{})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -100,7 +95,7 @@ func TestRPC_UnkownPeer_Call(t *testing.T) {
 		id: "B",
 	}
 
-	_, err = rpc.Call(ctx, fake.Message{}, mino.NewAddresses(to))
+	_, err := rpc.Call(ctx, fake.Message{}, mino.NewAddresses(to))
 	require.EqualError(t, err, "couldn't find peer: address <B> not found")
 }
 
@@ -108,8 +103,7 @@ func TestRPC_MissingHandler_Call(t *testing.T) {
 	manager := NewManager()
 
 	mA := MustCreate(manager, "A")
-	rpcA, err := mA.MakeRPC("test", fakeHandler{}, fake.MessageFactory{})
-	require.NoError(t, err)
+	rpcA := mino.MustCreateRPC(mA, "test", fakeHandler{}, fake.MessageFactory{})
 
 	mB := MustCreate(manager, "B")
 
@@ -127,12 +121,10 @@ func TestRPC_BadHandler_Call(t *testing.T) {
 	manager := NewManager()
 
 	mA := MustCreate(manager, "A")
-	rpcA, err := mA.MakeRPC("test", fakeHandler{}, fake.MessageFactory{})
-	require.NoError(t, err)
+	rpcA := mino.MustCreateRPC(mA, "test", fakeHandler{}, fake.MessageFactory{})
 
 	mB := MustCreate(manager, "B")
-	_, err = mB.MakeRPC("test", badHandler{}, fake.MessageFactory{})
-	require.NoError(t, err)
+	mino.MustCreateRPC(mB, "test", badHandler{}, fake.MessageFactory{})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -148,8 +140,7 @@ func TestRPC_Stream(t *testing.T) {
 	manager := NewManager()
 
 	m := MustCreate(manager, "A")
-	rpc, err := m.MakeRPC("test", fakeStreamHandler{}, fake.MessageFactory{})
-	require.NoError(t, err)
+	rpc := mino.MustCreateRPC(m, "test", fakeStreamHandler{}, fake.MessageFactory{})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -172,8 +163,8 @@ func TestRPC_Failures_Stream(t *testing.T) {
 	m := MustCreate(manager, "A")
 
 	m.context = fake.NewBadContext()
-	rpc, err := m.MakeRPC("test", fakeBadStreamHandler{}, fake.MessageFactory{})
-	require.NoError(t, err)
+
+	rpc := mino.MustCreateRPC(m, "test", fakeBadStreamHandler{}, fake.MessageFactory{})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/mino/minogrpc/example_test.go
+++ b/mino/minogrpc/example_test.go
@@ -16,20 +16,14 @@ func ExampleRPC_Call() {
 		panic("overlay A failed: " + err.Error())
 	}
 
-	rpcA, err := mA.MakeRPC("test", exampleHandler{}, exampleFactory{})
-	if err != nil {
-		panic("rpc A failed: " + err.Error())
-	}
+	rpcA := mino.MustCreateRPC(mA, "test", exampleHandler{}, exampleFactory{})
 
 	mB, err := NewMinogrpc(ParseAddress("127.0.0.1", 0), tree.NewRouter(NewAddressFactory()))
 	if err != nil {
 		panic("overlay B failed: " + err.Error())
 	}
 
-	_, err = mB.MakeRPC("test", exampleHandler{}, exampleFactory{})
-	if err != nil {
-		panic("rpc B failed: " + err.Error())
-	}
+	mino.MustCreateRPC(mB, "test", exampleHandler{}, exampleFactory{})
 
 	mA.GetCertificateStore().Store(mB.GetAddress(), mB.GetCertificate())
 	mB.GetCertificateStore().Store(mA.GetAddress(), mA.GetCertificate())
@@ -68,20 +62,14 @@ func ExampleRPC_Stream() {
 		panic("overlay A failed: " + err.Error())
 	}
 
-	rpcA, err := mA.MakeRPC("test", exampleHandler{}, exampleFactory{})
-	if err != nil {
-		panic("rpc A failed: " + err.Error())
-	}
+	rpcA := mino.MustCreateRPC(mA, "test", exampleHandler{}, exampleFactory{})
 
 	mB, err := NewMinogrpc(ParseAddress("127.0.0.1", 0), tree.NewRouter(NewAddressFactory()))
 	if err != nil {
 		panic("overlay B failed: " + err.Error())
 	}
 
-	_, err = mB.MakeRPC("test", exampleHandler{}, exampleFactory{})
-	if err != nil {
-		panic("rpc B failed: " + err.Error())
-	}
+	mino.MustCreateRPC(mB, "test", exampleHandler{}, exampleFactory{})
 
 	mA.GetCertificateStore().Store(mB.GetAddress(), mB.GetCertificate())
 	mB.GetCertificateStore().Store(mA.GetAddress(), mA.GetCertificate())

--- a/mino/minogrpc/mod_test.go
+++ b/mino/minogrpc/mod_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.dedis.ch/dela/internal/testing/fake"
+	"go.dedis.ch/dela/mino"
 	"go.dedis.ch/dela/mino/minogrpc/session"
 	"go.dedis.ch/dela/mino/minogrpc/tokens"
 	"go.dedis.ch/dela/mino/router/tree"
@@ -22,7 +23,7 @@ func TestMinogrpc_New(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, "127.0.0.1:3333", m.GetAddress().String())
-	require.Equal(t, "", m.namespace)
+	require.Empty(t, m.segments)
 
 	cert := m.GetCertificate()
 	require.NotNil(t, cert)
@@ -128,59 +129,61 @@ func TestMinogrpc_GracefulClose(t *testing.T) {
 	require.EqualError(t, err, "connection manager not empty: 1")
 }
 
-func TestMinogrpc_MakeNamespace(t *testing.T) {
-	minoGrpc := Minogrpc{}
+func TestMinogrpc_WithSegment(t *testing.T) {
+	m := &Minogrpc{}
 	ns := "Test"
-	newMino, err := minoGrpc.MakeNamespace(ns)
-	require.NoError(t, err)
+
+	newMino := m.WithSegment(ns)
 
 	newMinoGrpc, ok := newMino.(*Minogrpc)
 	require.True(t, ok)
+	require.Equal(t, ns, newMinoGrpc.segments[0])
 
-	require.Equal(t, "/"+ns, newMinoGrpc.namespace)
-
-	// A namespace can not be empty
-	ns = ""
-	_, err = minoGrpc.MakeNamespace(ns)
-	require.EqualError(t, err, "a namespace can not be empty")
-
-	// A namespace should match [a-zA-Z0-9]+
-	ns = "/namespace"
-	_, err = minoGrpc.MakeNamespace(ns)
-	require.EqualError(t, err, "a namespace should match [a-zA-Z0-9]+, but found '/namespace'")
-
-	ns = " test"
-	_, err = minoGrpc.MakeNamespace(ns)
-	require.EqualError(t, err, "a namespace should match [a-zA-Z0-9]+, but found ' test'")
-
-	ns = "test$"
-	_, err = minoGrpc.MakeNamespace(ns)
-	require.EqualError(t, err, "a namespace should match [a-zA-Z0-9]+, but found 'test$'")
+	newMino = m.WithSegment("")
+	require.Equal(t, m, newMino)
 }
 
-func TestMinogrpc_MakeRPC(t *testing.T) {
+func TestMinogrpc_CreateRPC(t *testing.T) {
 	m := Minogrpc{
-		namespace: "",
 		overlay:   &overlay{},
 		endpoints: make(map[string]*Endpoint),
 	}
 
-	mNs, err := m.MakeNamespace("namespace")
-	require.NoError(t, err)
+	mNs := m.WithSegment("segment")
 
-	rpc, err := mNs.MakeRPC("name", emptyHandler{}, fake.MessageFactory{})
+	rpc, err := mNs.CreateRPC("name", emptyHandler{}, fake.MessageFactory{})
 	require.NoError(t, err)
 
 	expectedRPC := &RPC{
 		factory: fake.MessageFactory{},
 		overlay: &overlay{},
-		uri:     "/namespace/name",
+		uri:     "segment/name",
 	}
 
 	endpoint, ok := m.endpoints[expectedRPC.uri]
 	require.True(t, ok)
 	require.Equal(t, emptyHandler{}, endpoint.Handler)
 	require.Equal(t, expectedRPC, rpc)
+
+	_, err = mNs.CreateRPC("name", emptyHandler{}, fake.MessageFactory{})
+	require.EqualError(t, err, "rpc 'segment/name' already exists")
+}
+
+func TestMinogrpc_InvalidSegment_CreateRPC(t *testing.T) {
+	m := &Minogrpc{
+		segments: []string{"example"},
+	}
+
+	handler := mino.UnsupportedHandler{}
+
+	_, err := m.CreateRPC("/test", handler, fake.MessageFactory{})
+	require.EqualError(t, err, "invalid segment in uri 'example//test': '/test'")
+
+	_, err = m.CreateRPC(" test", handler, fake.MessageFactory{})
+	require.EqualError(t, err, "invalid segment in uri 'example/ test': ' test'")
+
+	_, err = m.CreateRPC("test$", handler, fake.MessageFactory{})
+	require.EqualError(t, err, "invalid segment in uri 'example/test$': 'test$'")
 }
 
 func TestMinogrpc_String(t *testing.T) {

--- a/mino/minogrpc/server_test.go
+++ b/mino/minogrpc/server_test.go
@@ -831,11 +831,8 @@ func makeInstances(t *testing.T, n int, call *fake.Call) ([]mino.Mino, []mino.RP
 		m, err := NewMinogrpc(addr, tree.NewRouter(addressFac))
 		require.NoError(t, err)
 
-		rpc, err := m.MakeRPC("test", testHandler{call: call}, fake.MessageFactory{})
-		require.NoError(t, err)
-
 		mm[i] = m
-		rpcs[i] = rpc
+		rpcs[i] = mino.MustCreateRPC(m, "test", testHandler{call: call}, fake.MessageFactory{})
 
 		for _, k := range mm[:i] {
 			km := k.(*Minogrpc)

--- a/mino/mod_test.go
+++ b/mino/mod_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.dedis.ch/dela/serde"
+	"golang.org/x/xerrors"
 )
 
 func TestUnsupportedHandler_Process(t *testing.T) {
@@ -16,4 +18,35 @@ func TestUnsupportedHandler_Process(t *testing.T) {
 func TestUnsupportedHandler_Stream(t *testing.T) {
 	h := UnsupportedHandler{}
 	require.Error(t, h.Stream(nil, nil))
+}
+
+func TestMustCreateRPC(t *testing.T) {
+	rpc := MustCreateRPC(fakeMino{}, "name", nil, nil)
+	require.NotNil(t, rpc)
+}
+
+func TestMustCreateRPC_Panic(t *testing.T) {
+	defer func() {
+		err := recover().(error)
+		require.EqualError(t, err, "rpc_error")
+	}()
+
+	MustCreateRPC(fakeMino{err: xerrors.New("rpc_error")}, "name", nil, nil)
+}
+
+// -----------------------------------------------------------------------------
+// Utility functions
+
+type fakeRPC struct {
+	RPC
+}
+
+type fakeMino struct {
+	Mino
+
+	err error
+}
+
+func (m fakeMino) CreateRPC(name string, h Handler, f serde.Factory) (RPC, error) {
+	return fakeRPC{}, m.err
 }


### PR DESCRIPTION
This changes the way namespaces are defined. It now considers the namespace as something that already exists and you simply access it and it renames namespace to segment.