### PR TITLE
Serde: add XML to the example

### DIFF
--- a/serde/example_test.go
+++ b/serde/example_test.go
@@ -7,36 +7,48 @@ import (
 	"go.dedis.ch/dela/serde"
 	"go.dedis.ch/dela/serde/json"
 	"go.dedis.ch/dela/serde/registry"
+	"go.dedis.ch/dela/serde/xml"
 )
 
-func ExampleMessage_Serialize_json() {
+func ExampleMessage_Serialize() {
 	// Register a JSON format engine for the message type.
 	exampleRegistry.Register(serde.FormatJSON, exampleJSONFormat{})
+	// Register a Gob format engine for the message type.
+	exampleRegistry.Register(serde.FormatXML, exampleXMLFormat{})
 
 	msg := exampleMessage{
 		value: 42,
 	}
 
-	ctx := json.NewContext()
-
-	data, err := msg.Serialize(ctx)
+	data, err := msg.Serialize(json.NewContext())
 	if err != nil {
 		panic("serialization failed: " + err.Error())
 	}
 
-	fmt.Println(string(data))
+	fmt.Println("JSON", string(data))
 
-	// Output: {"value":42}
+	data, err = msg.Serialize(xml.NewContext())
+	if err != nil {
+		panic("serialization failed: " + err.Error())
+	}
+
+	fmt.Println("XML", string(data))
+
+	// Output: JSON {"value":42}
+	// XML <exampleMessageXML><value>42</value></exampleMessageXML>
 }
 
-func ExampleFactory_Deserialize_json() {
-	ctx := json.NewContext()
-
-	data := []byte(`{"Value":42}`)
-
+func ExampleFactory_Deserialize() {
 	factory := exampleFactory{}
 
-	msg, err := factory.Deserialize(ctx, data)
+	msg, err := factory.Deserialize(json.NewContext(), []byte(`{"Value":42}`))
+	if err != nil {
+		panic("deserialization failed: " + err.Error())
+	}
+
+	fmt.Printf("%+v\n", msg)
+
+	msg, err = factory.Deserialize(xml.NewContext(), []byte("<exampleMessageXML><value>12</value></exampleMessageXML>"))
 	if err != nil {
 		panic("deserialization failed: " + err.Error())
 	}
@@ -44,6 +56,7 @@ func ExampleFactory_Deserialize_json() {
 	fmt.Printf("%+v", msg)
 
 	// Output: {value:42}
+	// {value:12}
 }
 
 var exampleRegistry = registry.NewSimpleRegistry()
@@ -53,6 +66,19 @@ var exampleRegistry = registry.NewSimpleRegistry()
 // - implements serde.Message
 type exampleMessage struct {
 	value int
+}
+
+// Serialize implements serde.Message. It returns the JSON serialization of a
+// message example.
+func (m exampleMessage) Serialize(ctx serde.Context) ([]byte, error) {
+	format := exampleRegistry.Get(ctx.GetFormat())
+
+	data, err := format.Encode(ctx, m)
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
 }
 
 // exampleFactory is a example of a message factory.
@@ -82,19 +108,6 @@ type exampleMessageJSON struct {
 	Value int `json:"value"`
 }
 
-// Serialize implements serde.Message. It returns the JSON serialization of a
-// message example.
-func (m exampleMessage) Serialize(ctx serde.Context) ([]byte, error) {
-	format := exampleRegistry.Get(ctx.GetFormat())
-
-	data, err := format.Encode(ctx, m)
-	if err != nil {
-		return nil, err
-	}
-
-	return data, nil
-}
-
 // exampleJSONFormat is an example of a format to serialize a message example
 // using a JSON encoding.
 //
@@ -116,9 +129,52 @@ func (exampleJSONFormat) Encode(ctx serde.Context, msg serde.Message) ([]byte, e
 	return ctx.Marshal(m)
 }
 
-// Decode implements serde.FormatEngine. It is not implemented in this example.
+// Decode implements serde.FormatEngine. It populates a message example if
+// appropritate, otherwise it returns an error.
 func (exampleJSONFormat) Decode(ctx serde.Context, data []byte) (serde.Message, error) {
 	var m exampleMessageJSON
+	err := ctx.Unmarshal(data, &m)
+	if err != nil {
+		return nil, err
+	}
+
+	msg := exampleMessage{
+		value: m.Value,
+	}
+
+	return msg, nil
+}
+
+// exampleMessageXML is an XML message for a message example.
+type exampleMessageXML struct {
+	Value int `xml:"value"`
+}
+
+// exampleXMLFormat is an example if a format to serialize a message example
+// using the XML encoding.
+//
+// - implements serde.FormatEngine
+type exampleXMLFormat struct{}
+
+// Encode implements serde.FormatEngine. It formats the message to comply with
+// the XML encoding and marshal it.
+func (exampleXMLFormat) Encode(ctx serde.Context, msg serde.Message) ([]byte, error) {
+	example, ok := msg.(exampleMessage)
+	if !ok {
+		return nil, errors.New("unsupported message")
+	}
+
+	m := exampleMessageXML{
+		Value: example.value,
+	}
+
+	return ctx.Marshal(m)
+}
+
+// Decode implements serde.FormatEngine. It populates a message example if
+// appropritate, otherwise it returns an error.
+func (exampleXMLFormat) Decode(ctx serde.Context, data []byte) (serde.Message, error) {
+	var m exampleMessageXML
 	err := ctx.Unmarshal(data, &m)
 	if err != nil {
 		return nil, err

--- a/serde/mod.go
+++ b/serde/mod.go
@@ -21,6 +21,9 @@ type Format string
 const (
 	// FormatJSON is the identifier for JSON formats.
 	FormatJSON Format = "JSON"
+
+	// FormatXML is the identifier for XML formats.
+	FormatXML Format = "XML"
 )
 
 // Message is the interface that a message must implement.

--- a/serde/xml/mod.go
+++ b/serde/xml/mod.go
@@ -1,0 +1,39 @@
+// Package xml implements the context engine for the XML encoding.
+//
+// Documentation Last Review: 14.10.2020
+//
+package xml
+
+import (
+	"encoding/xml"
+
+	"go.dedis.ch/dela/serde"
+)
+
+// xmlEngine is a context engine that uses the XML encoding. See encoding/xml.
+//
+// - implements serde.ContextEngine
+type xmlEngine struct{}
+
+// NewContext returns a new serde context that is using the Gob encoding.
+func NewContext() serde.Context {
+	return serde.NewContext(xmlEngine{})
+}
+
+// GetFormat implements serde.ContextEngine. It returns the XML format
+// identifier.
+func (xmlEngine) GetFormat() serde.Format {
+	return serde.FormatXML
+}
+
+// Marshal implements serde.ContextEngine. It marshals the message using the XML
+// encoding.
+func (xmlEngine) Marshal(m interface{}) ([]byte, error) {
+	return xml.Marshal(m)
+}
+
+// Unmarshal implements serde.ContextEngine. It unmarshals the data into the
+// message using the XML encoding.
+func (xmlEngine) Unmarshal(data []byte, m interface{}) error {
+	return xml.Unmarshal(data, m)
+}

--- a/serde/xml/mod.go
+++ b/serde/xml/mod.go
@@ -15,7 +15,7 @@ import (
 // - implements serde.ContextEngine
 type xmlEngine struct{}
 
-// NewContext returns a new serde context that is using the Gob encoding.
+// NewContext returns a new serde context that is using the XML encoding.
 func NewContext() serde.Context {
 	return serde.NewContext(xmlEngine{})
 }

--- a/serde/xml/mod_test.go
+++ b/serde/xml/mod_test.go
@@ -1,0 +1,39 @@
+package xml
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.dedis.ch/dela/serde"
+)
+
+func TestXMLEngine_GetFormat(t *testing.T) {
+	ctx := NewContext()
+
+	require.Equal(t, serde.FormatXML, ctx.GetFormat())
+}
+
+func TestXMLEngine_Marshal(t *testing.T) {
+	ctx := NewContext()
+
+	data, err := ctx.Marshal(testMessage{Value: 42})
+	require.NoError(t, err)
+	require.Equal(t, "<testMessage><Value>42</Value></testMessage>", string(data))
+}
+
+func TestXMLEngine_Unmarshal(t *testing.T) {
+	ctx := NewContext()
+
+	var m testMessage
+
+	err := ctx.Unmarshal([]byte("<testMessage><Value>42</Value></testMessage>"), &m)
+	require.NoError(t, err)
+	require.Equal(t, 42, m.Value)
+}
+
+// -----------------------------------------------------------------------------
+// Utility functions
+
+type testMessage struct {
+	Value int
+}


### PR DESCRIPTION
This demonstrates how different formats can be used by simply switching the context.

Needs #143 