### PR TITLE
Router: Accept node's address

### DIFF
--- a/mino/minogrpc/example_test.go
+++ b/mino/minogrpc/example_test.go
@@ -57,14 +57,14 @@ func ExampleRPC_Call() {
 }
 
 func ExampleRPC_Stream() {
-	mA, err := NewMinogrpc(ParseAddress("127.0.0.1", 0), tree.NewRouter(NewAddressFactory()))
+	mA, err := NewMinogrpc(ParseAddress("127.0.0.1", 20000), tree.NewRouter(NewAddressFactory()))
 	if err != nil {
 		panic("overlay A failed: " + err.Error())
 	}
 
 	rpcA := mino.MustCreateRPC(mA, "test", exampleHandler{}, exampleFactory{})
 
-	mB, err := NewMinogrpc(ParseAddress("127.0.0.1", 0), tree.NewRouter(NewAddressFactory()))
+	mB, err := NewMinogrpc(ParseAddress("127.0.0.1", 30000), tree.NewRouter(NewAddressFactory()))
 	if err != nil {
 		panic("overlay B failed: " + err.Error())
 	}

--- a/mino/minogrpc/example_test.go
+++ b/mino/minogrpc/example_test.go
@@ -57,14 +57,14 @@ func ExampleRPC_Call() {
 }
 
 func ExampleRPC_Stream() {
-	mA, err := NewMinogrpc(ParseAddress("127.0.0.1", 20000), tree.NewRouter(NewAddressFactory()))
+	mA, err := NewMinogrpc(ParseAddress("127.0.0.1", 0), tree.NewRouter(NewAddressFactory()))
 	if err != nil {
 		panic("overlay A failed: " + err.Error())
 	}
 
 	rpcA := mino.MustCreateRPC(mA, "test", exampleHandler{}, exampleFactory{})
 
-	mB, err := NewMinogrpc(ParseAddress("127.0.0.1", 30000), tree.NewRouter(NewAddressFactory()))
+	mB, err := NewMinogrpc(ParseAddress("127.0.0.1", 0), tree.NewRouter(NewAddressFactory()))
 	if err != nil {
 		panic("overlay B failed: " + err.Error())
 	}

--- a/mino/minogrpc/rpc.go
+++ b/mino/minogrpc/rpc.go
@@ -146,7 +146,7 @@ func (rpc RPC) Stream(ctx context.Context, players mino.Players) (mino.Sender, m
 		headerStreamIDKey, streamID,
 		headerGatewayKey, rpc.overlay.myAddrStr)
 
-	table, err := rpc.overlay.router.New(mino.NewAddresses())
+	table, err := rpc.overlay.router.New(mino.NewAddresses(), rpc.overlay.myAddr)
 	if err != nil {
 		return nil, nil, xerrors.Errorf("routing table failed: %v", err)
 	}

--- a/mino/minogrpc/rpc_test.go
+++ b/mino/minogrpc/rpc_test.go
@@ -427,7 +427,7 @@ func (r badRouter) GetHandshakeFactory() router.HandshakeFactory {
 	return fakeHandshakeFactory{}
 }
 
-func (badRouter) New(mino.Players) (router.RoutingTable, error) {
+func (badRouter) New(mino.Players, mino.Address) (router.RoutingTable, error) {
 	return nil, fake.GetError()
 }
 

--- a/mino/minogrpc/server.go
+++ b/mino/minogrpc/server.go
@@ -366,7 +366,7 @@ func (o *overlayServer) tableFromHeaders(h metadata.MD) (router.RoutingTable, bo
 		addrs[i] = o.addrFactory.FromText([]byte(addr))
 	}
 
-	table, err := o.router.New(mino.NewAddresses(addrs...))
+	table, err := o.router.New(mino.NewAddresses(addrs...), o.myAddr)
 	if err != nil {
 		return nil, true, xerrors.Errorf("failed to create: %v", err)
 	}

--- a/mino/router/mod.go
+++ b/mino/router/mod.go
@@ -67,7 +67,7 @@ type Router interface {
 	GetHandshakeFactory() HandshakeFactory
 
 	// New creates a new routing table that will forward packets to the players.
-	New(mino.Players) (RoutingTable, error)
+	New(mino.Players, mino.Address) (RoutingTable, error)
 
 	// GenerateTableFrom returns the routing table associated to the handshake.
 	// A node should be able to route any incoming packet after receiving one.

--- a/mino/router/mod.go
+++ b/mino/router/mod.go
@@ -67,7 +67,7 @@ type Router interface {
 	GetHandshakeFactory() HandshakeFactory
 
 	// New creates a new routing table that will forward packets to the players.
-	New(mino.Players, mino.Address) (RoutingTable, error)
+	New(players mino.Players, me mino.Address) (RoutingTable, error)
 
 	// GenerateTableFrom returns the routing table associated to the handshake.
 	// A node should be able to route any incoming packet after receiving one.

--- a/mino/router/tree/example_test.go
+++ b/mino/router/tree/example_test.go
@@ -15,7 +15,7 @@ func ExampleRouter_New() {
 
 	players := mino.NewAddresses(addrA, addrB)
 
-	table, err := router.New(players)
+	table, err := router.New(players, addrA)
 	if err != nil {
 		panic("routing table failed: " + err.Error())
 	}
@@ -39,7 +39,7 @@ func ExampleTable_PrepareHandshakeFor() {
 
 	players := mino.NewAddresses(addrA, addrB)
 
-	table, err := routerA.New(players)
+	table, err := routerA.New(players, addrA)
 	if err != nil {
 		panic("routing table failed: " + err.Error())
 	}

--- a/mino/router/tree/mod.go
+++ b/mino/router/tree/mod.go
@@ -59,7 +59,7 @@ func (r Router) GetHandshakeFactory() router.HandshakeFactory {
 
 // New implements router.Router. It creates the routing table for the node that
 // is booting the protocol. This node will be the root of the tree.
-func (r Router) New(players mino.Players) (router.RoutingTable, error) {
+func (r Router) New(players mino.Players, address mino.Address) (router.RoutingTable, error) {
 	addrs := make([]mino.Address, 0, players.Len())
 	iter := players.AddressIterator()
 	for iter.HasNext() {

--- a/mino/router/tree/mod.go
+++ b/mino/router/tree/mod.go
@@ -59,7 +59,7 @@ func (r Router) GetHandshakeFactory() router.HandshakeFactory {
 
 // New implements router.Router. It creates the routing table for the node that
 // is booting the protocol. This node will be the root of the tree.
-func (r Router) New(players mino.Players, address mino.Address) (router.RoutingTable, error) {
+func (r Router) New(players mino.Players, me mino.Address) (router.RoutingTable, error) {
 	addrs := make([]mino.Address, 0, players.Len())
 	iter := players.AddressIterator()
 	for iter.HasNext() {

--- a/mino/router/tree/mod_test.go
+++ b/mino/router/tree/mod_test.go
@@ -27,7 +27,8 @@ func TestRouter_New(t *testing.T) {
 		router := NewRouter(fake.AddressFactory{})
 		router.maxHeight = int(height)
 
-		table, err := router.New(mino.NewAddresses(makeAddrs(int(n))...))
+		fakeAddrs := makeAddrs(int(n))
+		table, err := router.New(mino.NewAddresses(fakeAddrs...), fakeAddrs[0])
 		require.NoError(t, err)
 
 		return router.maxHeight == table.(Table).tree.GetMaxHeight()

--- a/mino/router/tree/mod_test.go
+++ b/mino/router/tree/mod_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.dedis.ch/dela/internal/testing/fake"
 	"go.dedis.ch/dela/mino"
+	minoRouter "go.dedis.ch/dela/mino/router"
 	"go.dedis.ch/dela/mino/router/tree/types"
 )
 
@@ -28,7 +29,15 @@ func TestRouter_New(t *testing.T) {
 		router.maxHeight = int(height)
 
 		fakeAddrs := makeAddrs(int(n))
-		table, err := router.New(mino.NewAddresses(fakeAddrs...), fakeAddrs[0])
+
+		var table minoRouter.RoutingTable
+		var err error
+
+		if n > 0 {
+			table, err = router.New(mino.NewAddresses(fakeAddrs...), fakeAddrs[0])
+		} else {
+			table, err = router.New(mino.NewAddresses(fakeAddrs...), nil)
+		}
 		require.NoError(t, err)
 
 		return router.maxHeight == table.(Table).tree.GetMaxHeight()


### PR DESCRIPTION
Some routing protocols require the router to know the node's address in order to decide the route.

This PR updates `Router.New` to accept the node's address. The `tree` router isn't changed since it doesn't make use of this information.