### PR TITLE
minogrpc: use node's IP while creating certificate

### DIFF
--- a/mino/minogrpc/mod.go
+++ b/mino/minogrpc/mod.go
@@ -101,7 +101,7 @@ type Minogrpc struct {
 }
 
 type minoTemplate struct {
-	myAddr mino.Address
+	myAddr session.Address
 	router router.Router
 	fac    mino.AddressFactory
 	certs  certs.Storage

--- a/mino/minogrpc/mod_test.go
+++ b/mino/minogrpc/mod_test.go
@@ -188,10 +188,10 @@ func TestMinogrpc_InvalidSegment_CreateRPC(t *testing.T) {
 
 func TestMinogrpc_String(t *testing.T) {
 	minoGrpc := &Minogrpc{
-		overlay: &overlay{myAddr: fake.NewAddress(0)},
+		overlay: &overlay{myAddr: session.Address{}},
 	}
 
-	require.Equal(t, "mino[fake.Address[0]]", minoGrpc.String())
+	require.Equal(t, "mino[]", minoGrpc.String())
 }
 
 // -----------------------------------------------------------------------------

--- a/mino/minogrpc/server.go
+++ b/mino/minogrpc/server.go
@@ -549,9 +549,16 @@ func (o *overlay) Join(addr, token string, certHash []byte) error {
 }
 
 func (o *overlay) makeCertificate() error {
+	// We take a substring from [1, N) because
+	// o.myAddrStr[0] == 'F' || o.myAddrStr[1] == 'O'
+	ip, _, err := net.SplitHostPort(o.myAddrStr[1:])
+	if err != nil {
+		return xerrors.Errorf("error parsing node's IP: %v", err)
+	}
+
 	tmpl := &x509.Certificate{
 		SerialNumber: big.NewInt(1),
-		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+		IPAddresses:  []net.IP{net.ParseIP(ip)},
 		NotBefore:    time.Now(),
 		NotAfter:     time.Now().Add(certificateDuration),
 

--- a/mino/minogrpc/server.go
+++ b/mino/minogrpc/server.go
@@ -554,7 +554,8 @@ func (o *overlay) makeCertificate() error {
 	// o.myAddrStr[0] == 'F' || o.myAddrStr[1] == 'O'
 	hostname, _, err := net.SplitHostPort(o.myAddrStr[1:])
 	if err != nil {
-		if _, ok := o.myAddr.(fake.Address); ok {
+		_, ok := o.myAddr.(fake.Address)
+		if ok {
 			hostname = "127.0.0.1"
 		} else {
 			return xerrors.Errorf("error parsing node's IP: %v", err)

--- a/mino/minogrpc/server.go
+++ b/mino/minogrpc/server.go
@@ -549,24 +549,13 @@ func (o *overlay) Join(addr, token string, certHash []byte) error {
 func (o *overlay) makeCertificate() error {
 	hostname, err := o.myAddr.GetHostname()
 	if err != nil {
-		return xerrors.Errorf("error parsing node's hostname: %v", err)
+		return xerrors.Errorf("error retrieving hostname: %v", err)
 	}
 
-	ipAddr := net.ParseIP(hostname)
-	var ipAddrs []net.IP
-
-	if ipAddr == nil {
-		addrs, err := net.LookupHost(hostname)
-		if err != nil {
-			return xerrors.Errorf("error resolving IP for %s: %v", hostname, err)
-		}
-		for _, ip := range addrs {
-			ipAddrs = append(ipAddrs, net.ParseIP(ip))
-		}
-	} else {
-		ipAddrs = append(ipAddrs, ipAddr)
+	ipAddrs, err := net.LookupIP(hostname)
+	if err != nil {
+		return xerrors.Errorf("error resolving IP: %v", err)
 	}
-
 	tmpl := &x509.Certificate{
 		SerialNumber: big.NewInt(1),
 		IPAddresses:  ipAddrs,

--- a/mino/minogrpc/server.go
+++ b/mino/minogrpc/server.go
@@ -556,6 +556,7 @@ func (o *overlay) makeCertificate() error {
 	if err != nil {
 		return xerrors.Errorf("error resolving IP: %v", err)
 	}
+
 	tmpl := &x509.Certificate{
 		SerialNumber: big.NewInt(1),
 		IPAddresses:  ipAddrs,

--- a/mino/minogrpc/server_test.go
+++ b/mino/minogrpc/server_test.go
@@ -178,7 +178,7 @@ func TestMinogrpc_Scenario_Failures(t *testing.T) {
 
 func TestOverlayServer_Join(t *testing.T) {
 	o, err := newOverlay(minoTemplate{
-		myAddr: fake.NewAddress(0),
+		myAddr: session.NewAddress("127.0.0.1:0"),
 		certs:  certs.NewInMemoryStore(),
 		router: tree.NewRouter(addressFac),
 		curve:  elliptic.P521(),
@@ -423,7 +423,7 @@ func TestOverlayServer_Stream(t *testing.T) {
 			router:      tree.NewRouter(addressFac),
 			context:     json.NewContext(),
 			addrFactory: addressFac,
-			myAddr:      fake.NewAddress(0),
+			myAddr:      session.NewAddress("127.0.0.1:0"),
 			closer:      &sync.WaitGroup{},
 			connMgr:     fakeConnMgr{},
 		},
@@ -634,7 +634,7 @@ func TestOverlay_Forward(t *testing.T) {
 			router:      tree.NewRouter(addressFac),
 			context:     json.NewContext(),
 			addrFactory: addressFac,
-			myAddr:      fake.NewAddress(0),
+			myAddr:      session.NewAddress("127.0.0.1:0"),
 			closer:      &sync.WaitGroup{},
 			connMgr:     fakeConnMgr{},
 		},
@@ -666,19 +666,16 @@ func TestOverlay_Forward(t *testing.T) {
 
 func TestOverlay_New(t *testing.T) {
 	o, err := newOverlay(minoTemplate{
-		myAddr: fake.NewAddress(0),
+		myAddr: session.NewAddress("127.0.0.1:0"),
 		certs:  certs.NewInMemoryStore(),
 		curve:  elliptic.P521(),
 		random: rand.Reader,
 	})
 	require.NoError(t, err)
 
-	cert, err := o.certs.Load(fake.NewAddress(0))
+	cert, err := o.certs.Load(session.NewAddress("127.0.0.1:0"))
 	require.NoError(t, err)
 	require.NotNil(t, cert)
-
-	_, err = newOverlay(minoTemplate{myAddr: fake.NewBadAddress()})
-	require.EqualError(t, err, fake.Err("failed to marshal address"))
 }
 
 func TestOverlay_Panic_GetCertificate(t *testing.T) {
@@ -709,7 +706,7 @@ func TestOverlay_Panic2_GetCertificate(t *testing.T) {
 
 func TestOverlay_Join(t *testing.T) {
 	overlay, err := newOverlay(minoTemplate{
-		myAddr: fake.NewAddress(0),
+		myAddr: session.NewAddress("127.0.0.1:0"),
 		certs:  certs.NewInMemoryStore(),
 		router: tree.NewRouter(addressFac),
 		fac:    addressFac,
@@ -728,7 +725,7 @@ func TestOverlay_Join(t *testing.T) {
 	err = overlay.Join("", "", nil)
 	require.NoError(t, err)
 
-	overlay.myAddr = fake.NewAddress(0)
+	overlay.myAddr = session.NewAddress("127.0.0.1:0")
 	overlay.certs = fakeCerts{err: fake.GetError()}
 	err = overlay.Join("", "", nil)
 	require.EqualError(t, err, fake.Err("couldn't fetch distant certificate"))


### PR DESCRIPTION
Required to exchange certificates when creating multiple nodes in a containerised environment with each container having a unique IP rather than `127.0.0.1`