### PR TITLE
Adds the access contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+cli/node/memcoin/memcoin

--- a/contracts/access/controller/action.go
+++ b/contracts/access/controller/action.go
@@ -1,0 +1,66 @@
+package controller
+
+import (
+	"encoding/base64"
+
+	"go.dedis.ch/dela"
+	"go.dedis.ch/dela/cli/node"
+	accessContract "go.dedis.ch/dela/contracts/access"
+	"go.dedis.ch/dela/core/access"
+	"go.dedis.ch/dela/core/execution/native"
+	"go.dedis.ch/dela/crypto/bls"
+	"golang.org/x/xerrors"
+)
+
+// addAction is an action to add one or more identities.
+//
+// - implements node.ActionTemplate
+type addAction struct{}
+
+// Execute implements node.ActionTemplate. It reads the list of identities and
+// update the access.
+func (a addAction) Execute(ctx node.Context) error {
+	var exec *native.Service
+	err := ctx.Injector.Resolve(&exec)
+	if err != nil {
+		return xerrors.Errorf("failed to resolve native service: %v", err)
+	}
+
+	var asrv access.Service
+	err = ctx.Injector.Resolve(&asrv)
+	if err != nil {
+		return xerrors.Errorf("failed to resolve access service: %v", err)
+	}
+
+	var accessStore accessStore
+	err = ctx.Injector.Resolve(&accessStore)
+	if err != nil {
+		return xerrors.Errorf("failed to resolve access store: %v", err)
+	}
+
+	idsStr := ctx.Flags.StringSlice("identity")
+	identities := make([]access.Identity, len(idsStr))
+
+	for i, id := range idsStr {
+		idBuf, err := base64.StdEncoding.DecodeString(id)
+		if err != nil {
+			return xerrors.Errorf("failed to decode pub key '%s': %v", id, err)
+		}
+
+		pk, err := bls.NewPublicKey(idBuf)
+		if err != nil {
+			return xerrors.Errorf("failed to unmarshal identity '%s': %v", id, err)
+		}
+
+		identities[i] = pk
+	}
+
+	err = asrv.Grant(accessStore, accessContract.NewCreds(aKey[:]), identities...)
+	if err != nil {
+		return xerrors.Errorf("failed to grant: %v", err)
+	}
+
+	dela.Logger.Info().Msgf("access granted to %v", identities)
+
+	return nil
+}

--- a/contracts/access/controller/action_test.go
+++ b/contracts/access/controller/action_test.go
@@ -1,0 +1,89 @@
+package controller
+
+import (
+	"encoding/base64"
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.dedis.ch/dela/cli"
+	"go.dedis.ch/dela/cli/node"
+	"go.dedis.ch/dela/core/execution/native"
+	"go.dedis.ch/dela/crypto/bls"
+	"go.dedis.ch/dela/internal/testing/fake"
+)
+
+func TestAddAction_Execute(t *testing.T) {
+	ctx := node.Context{
+		Injector: node.NewInjector(),
+		Flags:    make(node.FlagSet),
+		Out:      ioutil.Discard,
+	}
+
+	action := addAction{}
+	err := action.Execute(ctx)
+	require.EqualError(t, err, "failed to resolve native service: couldn't find dependency for '*native.Service'")
+
+	native := native.NewExecution()
+	ctx.Injector.Inject(native)
+
+	err = action.Execute(ctx)
+	require.EqualError(t, err, "failed to resolve access service: couldn't find dependency for 'access.Service'")
+
+	access := fakeAccess{}
+	ctx.Injector.Inject(&access)
+
+	err = action.Execute(ctx)
+	require.EqualError(t, err, "failed to resolve access store: couldn't find dependency for 'controller.accessStore'")
+
+	store := fakeStore{}
+	ctx.Injector.Inject(&store)
+
+	err = action.Execute(ctx)
+	require.NoError(t, err)
+
+	access.err = fake.GetError()
+
+	err = action.Execute(ctx)
+	require.EqualError(t, err, fake.Err("failed to grant"))
+
+	flags := fakeFlags{strings: make(map[string][]string)}
+	ctx.Flags = flags
+	flags.strings["identity"] = []string{"a"}
+
+	err = action.Execute(ctx)
+	require.EqualError(t, err, "failed to decode pub key 'a': illegal base64 data at input byte 0")
+
+	flags.strings["identity"] = []string{"AA=="}
+
+	err = action.Execute(ctx)
+	require.EqualError(t, err, "failed to unmarshal identity 'AA==': bn256.G2: not enough data")
+
+	signer := bls.NewSigner()
+	buf, err := signer.GetPublicKey().MarshalBinary()
+	require.NoError(t, err)
+	id := base64.StdEncoding.EncodeToString(buf)
+	flags.strings["identity"] = []string{id}
+
+	access.err = nil
+
+	err = action.Execute(ctx)
+	require.NoError(t, err)
+}
+
+// -----------------------------------------------------------------------------
+// Utility functions
+
+type fakeStore struct {
+	accessStore
+}
+
+type fakeFlags struct {
+	cli.Flags
+
+	strings map[string][]string
+}
+
+func (f fakeFlags) StringSlice(name string) []string {
+	return f.strings[name]
+}

--- a/contracts/access/controller/action_test.go
+++ b/contracts/access/controller/action_test.go
@@ -52,12 +52,12 @@ func TestAddAction_Execute(t *testing.T) {
 	flags.strings["identity"] = []string{"a"}
 
 	err = action.Execute(ctx)
-	require.EqualError(t, err, "failed to decode pub key 'a': illegal base64 data at input byte 0")
+	require.EqualError(t, err, "failed to parse identities: failed to decode pub key 'a': illegal base64 data at input byte 0")
 
 	flags.strings["identity"] = []string{"AA=="}
 
 	err = action.Execute(ctx)
-	require.EqualError(t, err, "failed to unmarshal identity 'AA==': bn256.G2: not enough data")
+	require.EqualError(t, err, "failed to parse identities: failed to unmarshal identity 'AA==': bn256.G2: not enough data")
 
 	signer := bls.NewSigner()
 	buf, err := signer.GetPublicKey().MarshalBinary()

--- a/contracts/access/controller/jstore.go
+++ b/contracts/access/controller/jstore.go
@@ -88,7 +88,7 @@ func (s *jstore) saveFile() error {
 		return xerrors.Errorf("failed to marshal data: %v", err)
 	}
 
-	err = ioutil.WriteFile(s.path, buf, os.ModePerm)
+	err = ioutil.WriteFile(s.path, buf, 0644)
 	if err != nil {
 		return xerrors.Errorf("failed to save file '%s': %v", s.path, err)
 	}

--- a/contracts/access/controller/jstore.go
+++ b/contracts/access/controller/jstore.go
@@ -1,3 +1,8 @@
+// This file implements a simple store based on a json file.
+//
+// Documentation Last Review: 02.02.2021
+//
+
 package controller
 
 import (
@@ -22,6 +27,12 @@ func newJstore(path string) (accessStore, error) {
 
 	ctx := json.NewContext()
 
+	jstore := &jstore{
+		ctx:  ctx,
+		path: path,
+		data: data,
+	}
+
 	if fileExist(path) {
 		buf, err := ioutil.ReadFile(path)
 		if err != nil {
@@ -32,13 +43,14 @@ func newJstore(path string) (accessStore, error) {
 		if err != nil {
 			return nil, xerrors.Errorf("failed to read json: %v", err)
 		}
+	} else {
+		err := jstore.saveFile()
+		if err != nil {
+			return nil, xerrors.Errorf("failed to save empty file: %v", err)
+		}
 	}
 
-	return &jstore{
-		ctx:  ctx,
-		path: path,
-		data: data,
-	}, nil
+	return jstore, nil
 }
 
 // jstore implements a simple store to store accesses on the access contract. It

--- a/contracts/access/controller/jstore.go
+++ b/contracts/access/controller/jstore.go
@@ -1,0 +1,102 @@
+package controller
+
+import (
+	"io/ioutil"
+	"os"
+	"sync"
+
+	"go.dedis.ch/dela/core/store"
+	"go.dedis.ch/dela/serde"
+	"go.dedis.ch/dela/serde/json"
+	"golang.org/x/xerrors"
+)
+
+// accessStore defines a simple read/write interface to store the access
+type accessStore interface {
+	store.Writable
+	store.Readable
+}
+
+func newJstore(path string) (accessStore, error) {
+	data := map[string][]byte{}
+
+	ctx := json.NewContext()
+
+	if fileExist(path) {
+		buf, err := ioutil.ReadFile(path)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to read file '%s': %v", path, err)
+		}
+
+		err = ctx.Unmarshal(buf, &data)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to read json: %v", err)
+		}
+	}
+
+	return &jstore{
+		ctx:  ctx,
+		path: path,
+		data: data,
+	}, nil
+}
+
+// jstore implements a simple store to store accesses on the access contract. It
+// keeps the data in memory AND in a json file.
+//
+// - implements accessStore
+type jstore struct {
+	sync.Mutex
+
+	ctx serde.Context
+
+	path string
+	data map[string][]byte
+}
+
+func (s *jstore) Set(key []byte, value []byte) error {
+	s.Lock()
+	defer s.Unlock()
+
+	s.data[string(key)] = value
+	s.saveFile()
+
+	return nil
+}
+
+func (s *jstore) Delete(key []byte) error {
+	s.Lock()
+	defer s.Unlock()
+
+	delete(s.data, string(key))
+	s.saveFile()
+
+	return nil
+}
+
+// return a nil value if not found
+func (s *jstore) Get(key []byte) ([]byte, error) {
+	s.Lock()
+	defer s.Unlock()
+
+	return s.data[string(key)], nil
+}
+
+func (s *jstore) saveFile() error {
+	buf, err := s.ctx.Marshal(s.data)
+	if err != nil {
+		return xerrors.Errorf("failed to marshal data: %v", err)
+	}
+
+	err = ioutil.WriteFile(s.path, buf, os.ModePerm)
+	if err != nil {
+		return xerrors.Errorf("failed to save file '%s': %v", s.path, err)
+	}
+
+	return nil
+}
+
+func fileExist(path string) bool {
+	_, err := os.Stat(path)
+	return !os.IsNotExist(err)
+}

--- a/contracts/access/controller/jstore_test.go
+++ b/contracts/access/controller/jstore_test.go
@@ -1,0 +1,141 @@
+package controller
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.dedis.ch/dela/internal/testing/fake"
+	"go.dedis.ch/dela/serde/json"
+)
+
+func TestJstore_New(t *testing.T) {
+	dir, err := ioutil.TempDir(os.TempDir(), "dela-test-")
+	require.NoError(t, err)
+
+	defer os.RemoveAll(dir)
+
+	path := filepath.Join(dir, "store.json")
+	store, err := newJstore(path)
+	require.NoError(t, err)
+
+	require.NotNil(t, store)
+
+	_, err = newJstore(dir)
+	require.Regexp(t, "^failed to read file", err.Error())
+
+	err = ioutil.WriteFile(path, []byte(""), os.ModePerm)
+	require.NoError(t, err)
+
+	_, err = newJstore(path)
+	require.EqualError(t, err, "failed to read json: unexpected end of JSON input")
+}
+
+func TestJstore_Set_Get_Delete(t *testing.T) {
+	dir, err := ioutil.TempDir(os.TempDir(), "dela-test-")
+	require.NoError(t, err)
+
+	defer os.RemoveAll(dir)
+	path := filepath.Join(dir, "store.json")
+	store, err := newJstore(path)
+	require.NoError(t, err)
+
+	key := []byte("key")
+	val := []byte("value")
+
+	resp, err := store.Get(key)
+	require.NoError(t, err)
+	require.Nil(t, resp)
+
+	err = store.Set(key, val)
+	require.NoError(t, err)
+
+	resp, err = store.Get(key)
+	require.NoError(t, err)
+	require.Equal(t, val, resp)
+
+	err = store.Delete(key)
+	require.NoError(t, err)
+
+	resp, err = store.Get(key)
+	require.NoError(t, err)
+	require.Nil(t, resp)
+}
+
+func TestJstore_SaveFile(t *testing.T) {
+	dir, err := ioutil.TempDir(os.TempDir(), "dela-test-")
+	require.NoError(t, err)
+
+	defer os.RemoveAll(dir)
+	path := filepath.Join(dir, "store.json")
+	store, err := newJstore(path)
+	require.NoError(t, err)
+
+	store.(*jstore).data["key"] = []byte("value")
+
+	err = store.(*jstore).saveFile()
+	require.NoError(t, err)
+
+	store.(*jstore).ctx = fake.NewBadContext()
+	err = store.(*jstore).saveFile()
+	require.EqualError(t, err, fake.Err("failed to marshal data"))
+
+	store.(*jstore).path = dir
+	store.(*jstore).ctx = json.NewContext()
+	err = store.(*jstore).saveFile()
+	require.Regexp(t, "^failed to save file", err.Error())
+}
+
+func TestJstore_Scenario(t *testing.T) {
+	dir, err := ioutil.TempDir(os.TempDir(), "dela-test-")
+	require.NoError(t, err)
+
+	defer os.RemoveAll(dir)
+
+	path := filepath.Join(dir, "store.json")
+	store, err := newJstore(path)
+	require.NoError(t, err)
+
+	key1 := []byte("key1")
+	val1 := []byte("value1")
+
+	key2 := []byte("key2")
+	val2 := []byte("value2")
+
+	err = store.Set(key1, val1)
+	require.NoError(t, err)
+
+	err = store.Set(key2, val2)
+	require.NoError(t, err)
+
+	// Reading and updating the file with a new store
+
+	store, err = newJstore(path)
+	require.NoError(t, err)
+
+	resp, err := store.Get(key1)
+	require.NoError(t, err)
+	require.Equal(t, val1, resp)
+
+	resp, err = store.Get(key2)
+	require.NoError(t, err)
+	require.Equal(t, val2, resp)
+
+	err = store.Delete(key1)
+	require.NoError(t, err)
+
+	// Reading with a 3rd store to see the update
+
+	store, err = newJstore(path)
+	require.NoError(t, err)
+
+	resp, err = store.Get(key1)
+	require.NoError(t, err)
+	require.Nil(t, resp)
+
+	resp, err = store.Get(key2)
+	require.NoError(t, err)
+	require.Equal(t, val2, resp)
+}

--- a/contracts/access/controller/jstore_test.go
+++ b/contracts/access/controller/jstore_test.go
@@ -31,6 +31,9 @@ func TestJstore_New(t *testing.T) {
 
 	_, err = newJstore(path)
 	require.EqualError(t, err, "failed to read json: unexpected end of JSON input")
+
+	_, err = newJstore("/fake/file")
+	require.Regexp(t, "^failed to save empty file:", err.Error())
 }
 
 func TestJstore_Set_Get_Delete(t *testing.T) {

--- a/contracts/access/controller/mod.go
+++ b/contracts/access/controller/mod.go
@@ -1,3 +1,7 @@
+// Package controller implements a controller for the access contract.
+//
+// Documentation Last Review: 02.02.2021
+//
 package controller
 
 import (

--- a/contracts/access/controller/mod.go
+++ b/contracts/access/controller/mod.go
@@ -1,0 +1,79 @@
+package controller
+
+import (
+	"path/filepath"
+
+	"go.dedis.ch/dela/cli"
+	"go.dedis.ch/dela/cli/node"
+	accessContract "go.dedis.ch/dela/contracts/access"
+	"go.dedis.ch/dela/core/access"
+	"go.dedis.ch/dela/core/execution/native"
+	"golang.org/x/xerrors"
+)
+
+var aKey = [32]byte{1}
+
+// newStore is the function used to create the new store. It allows us to create
+// a different store in the tests.
+var newStore = func(path string) (accessStore, error) {
+	return newJstore(path)
+}
+
+// miniController is a CLI initializer to allow a user to grant access to the
+// access contract.
+//
+// - implements node.Initializer
+type miniController struct{}
+
+// NewController creates a new minimal controller for the access contract.
+func NewController() node.Initializer {
+	return miniController{}
+}
+
+// SetCommands implements node.Initializer. It sets the command to control the
+// service.
+func (miniController) SetCommands(builder node.Builder) {
+	cmd := builder.SetCommand("access")
+	cmd.SetDescription("Handles the access contract")
+
+	sub := cmd.SetSubCommand("add")
+	sub.SetDescription("add an identity")
+	sub.SetFlags(cli.StringSliceFlag{
+		Name:     "identity",
+		Usage:    "identity to add, in the form of bls public keys",
+		Required: true,
+	})
+	sub.SetAction(builder.MakeAction(addAction{}))
+}
+
+// OnStart implements node.Initializer. It registers the access contract.
+func (m miniController) OnStart(flags cli.Flags, inj node.Injector) error {
+	var access access.Service
+	err := inj.Resolve(&access)
+	if err != nil {
+		return xerrors.Errorf("failed to resolve access service: %v", err)
+	}
+
+	var exec *native.Service
+	err = inj.Resolve(&exec)
+	if err != nil {
+		return xerrors.Errorf("failed to resolve native service: %v", err)
+	}
+
+	accessStore, err := newStore(filepath.Join(flags.String("config"), "access.json"))
+	if err != nil {
+		return xerrors.Errorf("failed to create access store: %v", err)
+	}
+
+	contract := accessContract.NewContract(aKey[:], access, accessStore)
+	accessContract.RegisterContract(exec, contract)
+
+	inj.Inject(accessStore)
+
+	return nil
+}
+
+// OnStop implements node.Initializer.
+func (miniController) OnStop(inj node.Injector) error {
+	return nil
+}

--- a/contracts/access/controller/mod_test.go
+++ b/contracts/access/controller/mod_test.go
@@ -1,0 +1,111 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.dedis.ch/dela/cli"
+	"go.dedis.ch/dela/cli/node"
+	"go.dedis.ch/dela/core/access"
+	"go.dedis.ch/dela/core/execution/native"
+	"go.dedis.ch/dela/core/store"
+	"go.dedis.ch/dela/internal/testing/fake"
+)
+
+func TestSetCommands(t *testing.T) {
+	ctrl := NewController()
+
+	call := &fake.Call{}
+	ctrl.SetCommands(fakeBuilder{call: call})
+
+	require.Equal(t, call.Len(), 7)
+}
+
+func TestOnStart(t *testing.T) {
+	ctrl := NewController()
+
+	injector := node.NewInjector()
+	err := ctrl.OnStart(node.FlagSet{}, injector)
+	require.EqualError(t, err, "failed to resolve access service: couldn't find dependency for 'access.Service'")
+
+	access := fakeAccess{}
+	injector.Inject(&access)
+
+	err = ctrl.OnStart(node.FlagSet{}, injector)
+	require.EqualError(t, err, "failed to resolve native service: couldn't find dependency for '*native.Service'")
+
+	native := native.NewExecution()
+	injector.Inject(native)
+
+	oldStore := newStore
+	newStore = func(path string) (accessStore, error) {
+		return nil, fake.GetError()
+	}
+
+	err = ctrl.OnStart(node.FlagSet{}, injector)
+	require.EqualError(t, err, fake.Err("failed to create access store"))
+
+	newStore = oldStore
+
+	err = ctrl.OnStart(node.FlagSet{}, injector)
+	require.NoError(t, err)
+}
+
+func TestOnStop(t *testing.T) {
+	ctrl := NewController()
+
+	err := ctrl.OnStop(nil)
+	require.NoError(t, err)
+}
+
+// -----------------------------------------------------------------------------
+// Utility functions
+
+type fakeCommandBuilder struct {
+	call *fake.Call
+}
+
+func (b fakeCommandBuilder) SetSubCommand(name string) cli.CommandBuilder {
+	b.call.Add(name)
+	return b
+}
+
+func (b fakeCommandBuilder) SetDescription(value string) {
+	b.call.Add(value)
+}
+
+func (b fakeCommandBuilder) SetFlags(flags ...cli.Flag) {
+	b.call.Add(flags)
+}
+
+func (b fakeCommandBuilder) SetAction(a cli.Action) {
+	b.call.Add(a)
+}
+
+type fakeBuilder struct {
+	call *fake.Call
+}
+
+func (b fakeBuilder) SetCommand(name string) cli.CommandBuilder {
+	b.call.Add(name)
+	return fakeCommandBuilder(b)
+}
+
+func (b fakeBuilder) SetStartFlags(flags ...cli.Flag) {
+	b.call.Add(flags)
+}
+
+func (b fakeBuilder) MakeAction(tmpl node.ActionTemplate) cli.Action {
+	b.call.Add(tmpl)
+	return nil
+}
+
+type fakeAccess struct {
+	access.Service
+
+	err error
+}
+
+func (a fakeAccess) Grant(store store.Snapshot, creds access.Credential, idents ...access.Identity) error {
+	return a.err
+}

--- a/contracts/access/mod.go
+++ b/contracts/access/mod.go
@@ -1,0 +1,171 @@
+// Package access implements a native contract to handle access. It allows an
+// authorized identity to add access as an {ID, CONTRACT, COMMAND, IDENTITIES}
+// quadruplet.
+//
+// ID is the credential identifier. This identifier is generally defined at the
+// contract's creation.
+// CONTRACT is the contract name.
+// COMMAND specifies the command to grant access to on the contract.
+// IDENTITIES is a list of base64 encoded bls public keys, separated by comas.
+package access
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"strings"
+
+	"go.dedis.ch/dela"
+	"go.dedis.ch/dela/core/access"
+	"go.dedis.ch/dela/core/execution"
+	"go.dedis.ch/dela/core/execution/native"
+	"go.dedis.ch/dela/core/store"
+	"go.dedis.ch/dela/crypto/bls"
+	"golang.org/x/xerrors"
+)
+
+const (
+	// ContractName is the name of the access contract.
+	ContractName = "go.dedis.ch/dela.Access"
+
+	// GrantIDArg is the argument's name in the transaction that contains the
+	// provided id to grant
+	GrantIDArg = "access:grant_id"
+
+	// GrantContractArg is the argument's name in the transaction that contain
+	// the provided contract name to grant the access to.
+	GrantContractArg = "access:grant_contract"
+
+	// GrantCommandArg is the argument's name in the transaction that contains
+	// the provided command to grant access to.
+	GrantCommandArg = "access:grant_command"
+
+	// IdentityArg is the argument's name in the transaction that contains the
+	// provided identity to grant access to.
+	IdentityArg = "access:identity"
+
+	// CmdArg is the argument's name to indicate the kind of command we want to
+	// run on the contract. Should be one of the Command type.
+	CmdArg = "access:command"
+)
+
+// Command defines a command for the value contract
+type Command string
+
+const (
+	// CmdSet defines the command to grant access
+	CmdSet Command = "GRANT"
+)
+
+// NewCreds creates new credentials for a value contract execution.
+func NewCreds(id []byte) access.Credential {
+	return access.NewContractCreds(id, ContractName, "all")
+}
+
+// RegisterContract registers the access contract to the given execution
+// service.
+func RegisterContract(exec *native.Service, c Contract) {
+	exec.Set(ContractName, c)
+}
+
+// Contract is the access contract that allows one to handle access.
+//
+// - implements native.Contract
+type Contract struct {
+	// access is the access service that will be modified.
+	access access.Service
+
+	// accessKey is the credential's ID allowed to use this smart contract
+	accessKey []byte
+
+	store store.Readable
+}
+
+// NewContract creates a new Value contract
+func NewContract(aKey []byte, srvc access.Service, store store.Readable) Contract {
+	return Contract{
+		access:    srvc,
+		accessKey: aKey,
+		store:     store,
+	}
+}
+
+// Execute implements native.Contract
+func (c Contract) Execute(snap store.Snapshot, step execution.Step) error {
+	creds := NewCreds(c.accessKey)
+
+	err := c.access.Match(c.store, creds, step.Current.GetIdentity())
+	if err != nil {
+		return xerrors.Errorf("identity not authorized: %v (%v)", step.Current.GetIdentity(), err)
+	}
+
+	cmd := step.Current.GetArg(CmdArg)
+	if len(cmd) == 0 {
+		return xerrors.Errorf("'%s' not found in tx arg", CmdArg)
+	}
+
+	switch Command(cmd) {
+	case CmdSet:
+		err := c.grant(snap, step)
+		if err != nil {
+			return xerrors.Errorf("failed to SET: %v", err)
+		}
+	default:
+		return xerrors.Errorf("unknown command: %s", cmd)
+	}
+
+	return nil
+}
+
+// grant perform the GRANT command
+func (c Contract) grant(snap store.Snapshot, step execution.Step) error {
+	idHex := step.Current.GetArg(GrantIDArg)
+	if len(idHex) == 0 {
+		return xerrors.Errorf("'%s' not found in tx arg", GrantIDArg)
+	}
+
+	id, err := hex.DecodeString(string(idHex))
+	if err != nil {
+		return xerrors.Errorf("failed to decode id: %v", err)
+	}
+
+	contractName := step.Current.GetArg(GrantContractArg)
+	if len(contractName) == 0 {
+		return xerrors.Errorf("'%s' not found in tx arg", GrantContractArg)
+	}
+
+	commandName := step.Current.GetArg(GrantCommandArg)
+	if len(commandName) == 0 {
+		return xerrors.Errorf("'%s' not found in tx arg", GrantCommandArg)
+	}
+
+	base64IDs := strings.Split(string(step.Current.GetArg(IdentityArg)), ",")
+	if len(base64IDs) == 0 || len(base64IDs[0]) == 0 {
+		return xerrors.Errorf("'%s' not found in tx arg", IdentityArg)
+	}
+
+	identities := make([]access.Identity, len(base64IDs))
+	for i, base64ID := range base64IDs {
+		identity, err := base64.StdEncoding.DecodeString(string(base64ID))
+		if err != nil {
+			return xerrors.Errorf("failed to decode base64ID: %v", err)
+		}
+
+		pubKey, err := bls.NewPublicKey(identity)
+		if err != nil {
+			return xerrors.Errorf("failed to get public key: %v", err)
+		}
+
+		identities[i] = pubKey
+	}
+
+	credential := access.NewContractCreds(id, string(contractName), string(commandName))
+	err = c.access.Grant(snap, credential, identities...)
+	if err != nil {
+		return xerrors.Errorf("failed to grant: %v", err)
+	}
+
+	dela.Logger.Info().Str("contract", "access").Msgf("granted %x-%s-%s to %s",
+		id, contractName, commandName, identities)
+
+	return nil
+}

--- a/contracts/access/mod.go
+++ b/contracts/access/mod.go
@@ -8,6 +8,9 @@
 // COMMAND specifies the command to grant access to on the contract.
 // IDENTITIES is a list of standard base64 encoded bls public keys, separated by
 // comas.
+//
+// Documentation Last Review: 02.02.2021
+//
 package access
 
 import (
@@ -47,6 +50,10 @@ const (
 	// CmdArg is the argument's name to indicate the kind of command we want to
 	// run on the contract. Should be one of the Command type.
 	CmdArg = "access:command"
+
+	// credentialAllCommand defines the credential command that is allowed to
+	// perform all commands.
+	credentialAllCommand = "all"
 )
 
 // Command defines a command for the command contract
@@ -59,7 +66,7 @@ const (
 
 // NewCreds creates new credentials for an access contract execution.
 func NewCreds(id []byte) access.Credential {
-	return access.NewContractCreds(id, ContractName, "all")
+	return access.NewContractCreds(id, ContractName, credentialAllCommand)
 }
 
 // RegisterContract registers the access contract to the given execution
@@ -126,7 +133,7 @@ func (c Contract) grant(snap store.Snapshot, step execution.Step) error {
 
 	id, err := hex.DecodeString(string(idHex))
 	if err != nil {
-		return xerrors.Errorf("failed to decode id: %v", err)
+		return xerrors.Errorf("failed to decode id from tx arg: %v", err)
 	}
 
 	contractName := step.Current.GetArg(GrantContractArg)

--- a/contracts/access/mod.go
+++ b/contracts/access/mod.go
@@ -6,7 +6,8 @@
 // contract's creation.
 // CONTRACT is the contract name.
 // COMMAND specifies the command to grant access to on the contract.
-// IDENTITIES is a list of base64 encoded bls public keys, separated by comas.
+// IDENTITIES is a list of standard base64 encoded bls public keys, separated by
+// comas.
 package access
 
 import (
@@ -48,7 +49,7 @@ const (
 	CmdArg = "access:command"
 )
 
-// Command defines a command for the value contract
+// Command defines a command for the command contract
 type Command string
 
 const (
@@ -56,7 +57,7 @@ const (
 	CmdSet Command = "GRANT"
 )
 
-// NewCreds creates new credentials for a value contract execution.
+// NewCreds creates new credentials for an access contract execution.
 func NewCreds(id []byte) access.Credential {
 	return access.NewContractCreds(id, ContractName, "all")
 }
@@ -80,7 +81,7 @@ type Contract struct {
 	store store.Readable
 }
 
-// NewContract creates a new Value contract
+// NewContract creates a new access contract
 func NewContract(aKey []byte, srvc access.Service, store store.Readable) Contract {
 	return Contract{
 		access:    srvc,

--- a/contracts/access/mod_test.go
+++ b/contracts/access/mod_test.go
@@ -48,7 +48,7 @@ func TestGrant(t *testing.T) {
 	require.EqualError(t, err, "'access:grant_id' not found in tx arg")
 
 	err = contract.grant(fakeStore{}, makeStep(t, GrantIDArg, "x"))
-	require.EqualError(t, err, "failed to decode id: encoding/hex: invalid byte: U+0078 'x'")
+	require.EqualError(t, err, "failed to decode id from tx arg: encoding/hex: invalid byte: U+0078 'x'")
 
 	err = contract.grant(fakeStore{}, makeStep(t, GrantIDArg, "deadbeef"))
 	require.EqualError(t, err, "'access:grant_contract' not found in tx arg")

--- a/contracts/access/mod_test.go
+++ b/contracts/access/mod_test.go
@@ -1,0 +1,142 @@
+package access
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.dedis.ch/dela/core/access"
+	"go.dedis.ch/dela/core/execution"
+	"go.dedis.ch/dela/core/execution/native"
+	"go.dedis.ch/dela/core/store"
+	"go.dedis.ch/dela/core/txn"
+	"go.dedis.ch/dela/core/txn/signed"
+	"go.dedis.ch/dela/crypto/bls"
+	"go.dedis.ch/dela/internal/testing/fake"
+)
+
+func TestExecute(t *testing.T) {
+	contract := NewContract([]byte{}, fakeAccess{err: fake.GetError()}, fakeStore{})
+	err := contract.Execute(fakeStore{}, makeStep(t, CmdArg, ""))
+	require.EqualError(t, err, "identity not authorized: fake.PublicKey ("+fake.GetError().Error()+")")
+
+	contract = NewContract([]byte{}, fakeAccess{}, fakeStore{})
+	err = contract.Execute(fakeStore{}, makeStep(t, CmdArg, ""))
+	require.EqualError(t, err, "'access:command' not found in tx arg")
+
+	err = contract.Execute(fakeStore{}, makeStep(t, CmdArg, "fake"))
+	require.EqualError(t, err, "unknown command: fake")
+
+	err = contract.Execute(fakeStore{}, makeStep(t, CmdArg, string(CmdSet)))
+	require.EqualError(t, err, "failed to SET: 'access:grant_id' not found in tx arg")
+
+	signer := bls.NewSigner()
+	buf, err := signer.GetPublicKey().MarshalBinary()
+	require.NoError(t, err)
+	id := base64.StdEncoding.EncodeToString(buf)
+	err = contract.Execute(fakeStore{}, makeStep(t, CmdArg, string(CmdSet),
+		GrantIDArg, "deadbeef",
+		GrantContractArg, "fake contract",
+		GrantCommandArg, "fake command",
+		IdentityArg, id))
+	require.NoError(t, err)
+}
+
+func TestGrant(t *testing.T) {
+	contract := NewContract([]byte{}, fakeAccess{}, fakeStore{})
+	err := contract.grant(fakeStore{}, makeStep(t))
+	require.EqualError(t, err, "'access:grant_id' not found in tx arg")
+
+	err = contract.grant(fakeStore{}, makeStep(t, GrantIDArg, "x"))
+	require.EqualError(t, err, "failed to decode id: encoding/hex: invalid byte: U+0078 'x'")
+
+	err = contract.grant(fakeStore{}, makeStep(t, GrantIDArg, "deadbeef"))
+	require.EqualError(t, err, "'access:grant_contract' not found in tx arg")
+
+	err = contract.grant(fakeStore{}, makeStep(t, GrantIDArg, "deadbeef",
+		GrantContractArg, "fake"))
+	require.EqualError(t, err, "'access:grant_command' not found in tx arg")
+
+	err = contract.grant(fakeStore{}, makeStep(t, GrantIDArg, "deadbeef",
+		GrantContractArg, "fake contract",
+		GrantCommandArg, "fake command"))
+	require.EqualError(t, err, "'access:identity' not found in tx arg")
+
+	err = contract.grant(fakeStore{}, makeStep(t, GrantIDArg, "deadbeef",
+		GrantContractArg, "fake contract",
+		GrantCommandArg, "fake command",
+		IdentityArg, "x"))
+	require.EqualError(t, err, "failed to decode base64ID: illegal base64 data at input byte 0")
+
+	err = contract.grant(fakeStore{}, makeStep(t, GrantIDArg, "deadbeef",
+		GrantContractArg, "fake contract",
+		GrantCommandArg, "fake command",
+		IdentityArg, "AA=="))
+	require.EqualError(t, err, "failed to get public key: bn256.G2: not enough data")
+
+	signer := bls.NewSigner()
+	buf, err := signer.GetPublicKey().MarshalBinary()
+	require.NoError(t, err)
+	id := base64.StdEncoding.EncodeToString(buf)
+	err = contract.grant(fakeStore{}, makeStep(t, GrantIDArg, "deadbeef",
+		GrantContractArg, "fake contract",
+		GrantCommandArg, "fake command",
+		IdentityArg, id))
+	require.NoError(t, err)
+
+	contract = NewContract([]byte{}, fakeAccess{err: fake.GetError()}, fakeStore{})
+	err = contract.grant(fakeStore{}, makeStep(t, GrantIDArg, "deadbeef",
+		GrantContractArg, "fake contract",
+		GrantCommandArg, "fake command",
+		IdentityArg, id))
+	require.EqualError(t, err, fake.Err("failed to grant"))
+}
+
+func TestRegisterContract(t *testing.T) {
+	RegisterContract(native.NewExecution(), Contract{})
+}
+
+// -----------------------------------------------------------------------------
+// Utility functions
+
+func makeStep(t *testing.T, args ...string) execution.Step {
+	return execution.Step{Current: makeTx(t, args...)}
+}
+
+func makeTx(t *testing.T, args ...string) txn.Transaction {
+	options := []signed.TransactionOption{}
+	for i := 0; i < len(args)-1; i += 2 {
+		options = append(options, signed.WithArg(args[i], []byte(args[i+1])))
+	}
+
+	tx, err := signed.NewTransaction(0, fake.PublicKey{}, options...)
+	require.NoError(t, err)
+
+	return tx
+}
+
+type fakeAccess struct {
+	access.Service
+
+	err error
+}
+
+func (srvc fakeAccess) Match(store.Readable, access.Credential, ...access.Identity) error {
+	return srvc.err
+}
+
+func (srvc fakeAccess) Grant(store.Snapshot, access.Credential, ...access.Identity) error {
+	return srvc.err
+}
+
+type fakeStore struct {
+	store.Snapshot
+}
+
+func (s fakeStore) Get(key []byte) ([]byte, error) {
+	return nil, nil
+}
+
+func (s fakeStore) Set(key, value []byte) error {
+	return nil
+}


### PR DESCRIPTION
Adds an access contract that allows an authorized identity to grant access on the other smart contracts. Each node must locally grant access to the identity that can use this smart contract, with the cli, in the form:

```
memcoin [--config /tmp/node1] access add [--identity IDENTITY ...]
```

As this access is critical and can be different on each node, it is kept in a separate storage on each server and not part of the blockchain.