### PR TITLE
TCP execution: change order of parsing addr

### DIFF
--- a/core/execution/benchmark/mod_test.go
+++ b/core/execution/benchmark/mod_test.go
@@ -13,13 +13,13 @@ import (
 
 const iterations = 50
 
-//func BenchmarkLocal(b *testing.B) {
-	//testWithAddr(b, "127.0.0.1:12346")
-//}
+func BenchmarkLocal(b *testing.B) {
+	testWithAddr(b, "127.0.0.1:12346")
+}
 
-//func BenchmarkUnikernel(b *testing.B) {
-	//testWithAddr(b, "192.168.232.128:12345")
-//}
+func BenchmarkUnikernel(b *testing.B) {
+	testWithAddr(b, "192.168.232.128:12345")
+}
 
 func BenchmarkEVM(b *testing.B) {
 	n := iterations

--- a/core/execution/tcp/mod.go
+++ b/core/execution/tcp/mod.go
@@ -43,7 +43,10 @@ func (hs *Service) Execute(snap store.Snapshot, step execution.Step) (execution.
 
 	addr := os.Getenv("UNIKERNEL_TCP")
 	if addr == "" {
-		addr = defaultUnikernelAddr
+		addr = string(step.Current.GetArg(addrArg))
+		if addr == "" {
+			addr = defaultUnikernelAddr
+		}
 	}
 
 	conn, err := net.DialTimeout("tcp", string(addr), dialTimeout)

--- a/core/execution/tcp/mod.go
+++ b/core/execution/tcp/mod.go
@@ -41,9 +41,9 @@ func (hs *Service) Execute(snap store.Snapshot, step execution.Step) (execution.
 		current = make([]byte, 8)
 	}
 
-	addr := os.Getenv("UNIKERNEL_TCP")
+	addr := string(step.Current.GetArg(addrArg))
 	if addr == "" {
-		addr = string(step.Current.GetArg(addrArg))
+		addr = os.Getenv("UNIKERNEL_TCP")
 		if addr == "" {
 			addr = defaultUnikernelAddr
 		}


### PR DESCRIPTION
Changes the order of parsing tcp endpoint to:

1. The argument passed in `step`
2. The environment variable `UNIKERNEL_TCP`
3. Defaulting to `defaultUnikernelAddr`