### PR TITLE
Exposes Prometheus collectors

### DIFF
--- a/core/ordering/cosipbft/pbft/mod.go
+++ b/core/ordering/cosipbft/pbft/mod.go
@@ -19,8 +19,8 @@ import (
 	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/rs/zerolog"
+	"go.dedis.ch/dela"
 	"go.dedis.ch/dela/core"
 	"go.dedis.ch/dela/core/ordering/cosipbft/authority"
 	"go.dedis.ch/dela/core/ordering/cosipbft/blockstore"
@@ -57,24 +57,24 @@ func (s State) String() string {
 
 // defines prometheus metrics
 var (
-	promBlocks = promauto.NewGauge(prometheus.GaugeOpts{
+	promBlocks = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "dela_cosipbft_blocks_total",
 		Help: "total number of blocks",
 	})
 
-	promTxs = promauto.NewHistogram(prometheus.HistogramOpts{
+	promTxs = prometheus.NewHistogram(prometheus.HistogramOpts{
 		Name:    "dela_cosipbft_transactions_block",
 		Help:    "total number of transactions in the last block",
 		Buckets: []float64{0, 1, 2, 3, 5, 8, 13, 20, 30, 50, 100},
 	})
 
-	promRejectedTxs = promauto.NewHistogram(prometheus.HistogramOpts{
+	promRejectedTxs = prometheus.NewHistogram(prometheus.HistogramOpts{
 		Name:    "dela_cosipbft_transactions_rejected_block",
 		Help:    "total number of rejected transactions in the last block",
 		Buckets: []float64{0, 1, 2, 3, 5, 8, 13, 20, 30, 50, 100},
 	})
 
-	promLeader = promauto.NewGauge(prometheus.GaugeOpts{
+	promLeader = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "dela_cosipbft_leader",
 		Help: "leader index from the roster",
 	})
@@ -100,6 +100,11 @@ const (
 	// the machine is waiting for view change requests.
 	ViewChangeState
 )
+
+func init() {
+	dela.PromCollectors = append(dela.PromCollectors, promBlocks, promTxs,
+		promRejectedTxs, promLeader)
+}
 
 // StateMachine is the interface to implement to support a PBFT protocol.
 type StateMachine interface {

--- a/mino/proxy/http/controller/action.go
+++ b/mino/proxy/http/controller/action.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"go.dedis.ch/dela"
 	"go.dedis.ch/dela/cli/node"
 	"go.dedis.ch/dela/mino/proxy"
 	"go.dedis.ch/dela/mino/proxy/http"
@@ -56,8 +58,15 @@ func (a promAction) Execute(ctx node.Context) error {
 
 	path := ctx.Flags.String("path")
 
+	for _, c := range dela.PromCollectors {
+		err = prometheus.DefaultRegisterer.Register(c)
+		if err != nil {
+			fmt.Fprintf(ctx.Out, "ERROR: failed to register: %v", err)
+		}
+	}
+
 	proxyhttp.RegisterHandler(path, promhttp.Handler().ServeHTTP)
-	fmt.Fprintf(ctx.Out, "registered prometheus service on %q\n", path)
+	fmt.Fprintf(ctx.Out, "registered prometheus service on %q", path)
 
 	return nil
 }

--- a/mino/proxy/http/controller/mod.go
+++ b/mino/proxy/http/controller/mod.go
@@ -37,7 +37,8 @@ func (m minimal) SetCommands(builder node.Builder) {
 
 	sub = cmd.SetSubCommand("prom")
 
-	sub.SetDescription("start a prometheus handler")
+	sub.SetDescription("registers the collectors and starts a prometheus handler. " +
+		"Will panic if the path is used more than once.")
 	sub.SetFlags(cli.StringFlag{
 		Name:     "path",
 		Required: false,


### PR DESCRIPTION
Changed the way we use Prometheus: Dela exposes the collectors it defines, and it is left to the developper to register them, or not. Like so, a foreign application can use its existing Prometheus registry and simply add the Dela metrics.