### PR TITLE
Adds an action to delete certificates

### DIFF
--- a/mino/minogrpc/controller/mod.go
+++ b/mino/minogrpc/controller/mod.go
@@ -76,6 +76,15 @@ func (m miniController) SetCommands(builder node.Builder) {
 	sub.SetDescription("list the certificates of the server")
 	sub.SetAction(builder.MakeAction(certAction{}))
 
+	rm := sub.SetSubCommand("rm")
+	rm.SetDescription("remove a certificate")
+	rm.SetFlags(cli.StringFlag{
+		Name:     "address",
+		Usage:    "address associated to the certificate(s), in base64",
+		Required: true,
+	})
+	rm.SetAction(builder.MakeAction(removeAction{}))
+
 	sub = cmd.SetSubCommand("token")
 	sub.SetDescription("generate a token to share to others to join the network")
 	sub.SetFlags(

--- a/mino/minogrpc/controller/mod_test.go
+++ b/mino/minogrpc/controller/mod_test.go
@@ -23,7 +23,7 @@ func TestMiniController_Build(t *testing.T) {
 	call := &fake.Call{}
 	ctrl.SetCommands(fakeBuilder{call: call})
 
-	require.Equal(t, 17, call.Len())
+	require.Equal(t, 22, call.Len())
 }
 
 func TestMiniController_OnStart(t *testing.T) {


### PR DESCRIPTION
Sometimes we need to remove an existing certificate from a node. This PR adds a `memcoin minogrpc certificates rm --address <addr>` CLI command to do that.
This is especially convenient when we need to regenerate a node's certificate, for example when its public address has changed.