### PR TITLE
Adds a flat routing implementation

### DIFF
--- a/mino/router/flat/json/mod.go
+++ b/mino/router/flat/json/mod.go
@@ -1,0 +1,156 @@
+package json
+
+import (
+	"go.dedis.ch/dela/mino"
+	"go.dedis.ch/dela/mino/router/flat/types"
+	"go.dedis.ch/dela/serde"
+	"golang.org/x/xerrors"
+)
+
+func init() {
+	types.RegisterPacketFormat(serde.FormatJSON, packetFormat{})
+	types.RegisterHandshakeFormat(serde.FormatJSON, hsFormat{})
+}
+
+// PacketJSON describes a JSON formatted packet
+type PacketJSON struct {
+	Source  []byte
+	Dest    [][]byte
+	Message []byte
+}
+
+// HandshakeJSON is the JSON message for the handshake.
+type HandshakeJSON struct {
+	Addresses [][]byte
+}
+
+// packetFormat is the engine to encode and decode Packets in JSON format.
+//
+// - implements serde.FormatEngine
+type packetFormat struct{}
+
+// Encode implements serde.FormatEngine. It returns the serialized data for the
+// packet if appropriate, otherwise it returns an error.
+func (f packetFormat) Encode(ctx serde.Context, msg serde.Message) ([]byte, error) {
+	packet, ok := msg.(*types.Packet)
+	if !ok {
+		return nil, xerrors.Errorf("unsupported message '%T'", msg)
+	}
+
+	source, err := packet.GetSource().MarshalText()
+	if err != nil {
+		return nil, xerrors.Errorf("failed to marshal source addr: %v", err)
+	}
+
+	dest := make([][]byte, len(packet.GetDestination()))
+
+	for i, addr := range packet.GetDestination() {
+		addBuf, err := addr.MarshalText()
+		if err != nil {
+			return nil, xerrors.Errorf("failed to marshal dest addr: %v", err)
+		}
+
+		dest[i] = addBuf
+	}
+
+	p := PacketJSON{
+		Source:  source,
+		Dest:    dest,
+		Message: packet.GetMessage(),
+	}
+
+	data, err := ctx.Marshal(p)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to marshal packet: %v", err)
+	}
+
+	return data, nil
+}
+
+// Decode implements serde.FormatEngine. It populates the packet if appropriate,
+// otherwise it returns an error.
+func (f packetFormat) Decode(ctx serde.Context, data []byte) (serde.Message, error) {
+	p := PacketJSON{}
+
+	err := ctx.Unmarshal(data, &p)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to unmarshal packet: %v", err)
+	}
+
+	factory := ctx.GetFactory(types.AddrKey{})
+
+	fac, ok := factory.(mino.AddressFactory)
+	if !ok {
+		return nil, xerrors.Errorf("invalid address factory '%T'", factory)
+	}
+
+	source := fac.FromText(p.Source)
+	dest := make([]mino.Address, len(p.Dest))
+
+	for i, buf := range p.Dest {
+		dest[i] = fac.FromText(buf)
+	}
+
+	packet := types.NewPacket(source, p.Message, dest...)
+
+	return packet, nil
+}
+
+// HandshakeFormat is the format engine to encode and decode handshake messages.
+//
+// - implements serde.FormatEngine
+type hsFormat struct{}
+
+// Encode implements serde.FormatEngine. It returns the serialized data for the
+// handshake if appropriate, otherwise it returns an error.
+func (hsFormat) Encode(ctx serde.Context, msg serde.Message) ([]byte, error) {
+	hs, ok := msg.(types.Handshake)
+	if !ok {
+		return nil, xerrors.Errorf("unsupported message '%T'", msg)
+	}
+
+	addrs := make([][]byte, len(hs.GetKnown()))
+	for i, addr := range hs.GetKnown() {
+		raw, err := addr.MarshalText()
+		if err != nil {
+			return nil, xerrors.Errorf("failed to marshal address: %v", err)
+		}
+
+		addrs[i] = raw
+	}
+
+	m := HandshakeJSON{
+		Addresses: addrs,
+	}
+
+	data, err := ctx.Marshal(m)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to marshal handshake: %v", err)
+	}
+
+	return data, nil
+}
+
+// Decode implements serde.FormatEngine. It populates the handshake if
+// appropriate, otherwise it returns an error.
+func (hsFormat) Decode(ctx serde.Context, data []byte) (serde.Message, error) {
+	m := HandshakeJSON{}
+	err := ctx.Unmarshal(data, &m)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to unmarshal: %v", err)
+	}
+
+	fac := ctx.GetFactory(types.AddrKey{})
+
+	factory, ok := fac.(mino.AddressFactory)
+	if !ok {
+		return nil, xerrors.Errorf("invalid address factory '%T'", fac)
+	}
+
+	addrs := make([]mino.Address, len(m.Addresses))
+	for i, raw := range m.Addresses {
+		addrs[i] = factory.FromText(raw)
+	}
+
+	return types.NewHandshake(addrs...), nil
+}

--- a/mino/router/flat/json/mod_test.go
+++ b/mino/router/flat/json/mod_test.go
@@ -1,0 +1,91 @@
+package json
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.dedis.ch/dela/internal/testing/fake"
+	"go.dedis.ch/dela/mino/router/flat/types"
+	"go.dedis.ch/dela/serde"
+)
+
+func TestPacketFormat_Encode(t *testing.T) {
+	fmt := packetFormat{}
+
+	ctx := fake.NewContext()
+	pkt := types.NewPacket(fake.NewAddress(0), []byte("data"), fake.NewAddress(1))
+
+	data, err := fmt.Encode(ctx, pkt)
+	require.NoError(t, err)
+	require.Equal(t, `{"Source":"AAAAAA==","Dest":["AQAAAA=="],"Message":"ZGF0YQ=="}`, string(data))
+
+	_, err = fmt.Encode(ctx, fake.Message{})
+	require.EqualError(t, err, "unsupported message 'fake.Message'")
+
+	_, err = fmt.Encode(ctx, types.NewPacket(fake.NewBadAddress(), nil))
+	require.EqualError(t, err, fake.Err("failed to marshal source addr"))
+
+	_, err = fmt.Encode(ctx, types.NewPacket(fake.NewAddress(0), nil, fake.NewBadAddress()))
+	require.EqualError(t, err, fake.Err("failed to marshal dest addr"))
+
+	_, err = fmt.Encode(fake.NewBadContext(), pkt)
+	require.EqualError(t, err, fake.Err("failed to marshal packet"))
+}
+
+func TestPacketFormat_Decode(t *testing.T) {
+	fmt := packetFormat{}
+
+	pkt := types.NewPacket(fake.NewAddress(0), []byte{}, fake.NewAddress(1))
+
+	ctx := fake.NewContext()
+	ctx = serde.WithFactory(ctx, types.AddrKey{}, fake.AddressFactory{})
+
+	msg, err := fmt.Decode(ctx, []byte(`{"Message":"","Dest":["AQAAAA=="]}`))
+	require.NoError(t, err)
+	require.Equal(t, pkt, msg)
+
+	_, err = fmt.Decode(fake.NewBadContext(), []byte(`{}`))
+	require.EqualError(t, err, fake.Err("failed to unmarshal packet"))
+
+	badCtx := serde.WithFactory(ctx, types.AddrKey{}, nil)
+	_, err = fmt.Decode(badCtx, []byte(`{}`))
+	require.EqualError(t, err, "invalid address factory '<nil>'")
+}
+
+func TestHandshakeFormat_Encode(t *testing.T) {
+	fmt := hsFormat{}
+
+	ctx := fake.NewContext()
+	hs := types.NewHandshake(fake.NewAddress(1))
+
+	data, err := fmt.Encode(ctx, hs)
+	require.NoError(t, err)
+	require.Equal(t, `{"Addresses":["AQAAAA=="]}`, string(data))
+
+	_, err = fmt.Encode(ctx, fake.Message{})
+	require.EqualError(t, err, "unsupported message 'fake.Message'")
+
+	_, err = fmt.Encode(ctx, types.NewHandshake(fake.NewBadAddress()))
+	require.EqualError(t, err, fake.Err("failed to marshal address"))
+
+	_, err = fmt.Encode(fake.NewBadContext(), hs)
+	require.EqualError(t, err, fake.Err("failed to marshal handshake"))
+}
+
+func TestHandshakeFormat_Decode(t *testing.T) {
+	fmt := hsFormat{}
+
+	ctx := fake.NewContext()
+	ctx = serde.WithFactory(ctx, types.AddrKey{}, fake.AddressFactory{})
+
+	msg, err := fmt.Decode(ctx, []byte(`{"Addresses":["AQAAAA=="]}`))
+	require.NoError(t, err)
+	require.Equal(t, types.NewHandshake(fake.NewAddress(1)), msg)
+
+	_, err = fmt.Decode(fake.NewBadContext(), []byte(`{}`))
+	require.EqualError(t, err, fake.Err("failed to unmarshal"))
+
+	badCtx := serde.WithFactory(ctx, types.AddrKey{}, nil)
+	_, err = fmt.Decode(badCtx, []byte(`{}`))
+	require.EqualError(t, err, "invalid address factory '<nil>'")
+}

--- a/mino/router/flat/mod.go
+++ b/mino/router/flat/mod.go
@@ -1,0 +1,127 @@
+// Package flat implements a flat routing that assumes a N-N connectivity among
+// nodes.
+//
+package flat
+
+import (
+	"go.dedis.ch/dela/mino"
+	"go.dedis.ch/dela/mino/router"
+	"go.dedis.ch/dela/mino/router/flat/types"
+	"golang.org/x/xerrors"
+)
+
+// Router is an implementation of a router producing direct routes
+//
+// - implements router.Router
+type Router struct {
+	packetFac router.PacketFactory
+	hsFac     router.HandshakeFactory
+}
+
+// NewRouter returns a new router.
+func NewRouter(f mino.AddressFactory) Router {
+	fac := types.NewPacketFactory(f)
+	hsFac := types.NewHandshakeFactory(f)
+
+	r := Router{
+		packetFac: fac,
+		hsFac:     hsFac,
+	}
+
+	return r
+}
+
+// GetPacketFactory implements router.Router. It returns the packet factory.
+func (r Router) GetPacketFactory() router.PacketFactory {
+	return r.packetFac
+}
+
+// GetHandshakeFactory implements router.Router. It returns the handshake
+// factory.
+func (r Router) GetHandshakeFactory() router.HandshakeFactory {
+	return r.hsFac
+}
+
+// New implements router.Router.
+func (r Router) New(players mino.Players, me mino.Address) (router.RoutingTable, error) {
+	addrs := make([]mino.Address, 0, players.Len())
+	iter := players.AddressIterator()
+	for iter.HasNext() {
+		addrs = append(addrs, iter.GetNext())
+	}
+
+	return NewTable(addrs), nil
+}
+
+// GenerateTableFrom implements router.Router. It creates the routing table
+// associated with the handshake that can contain some parameter.
+func (r Router) GenerateTableFrom(h router.Handshake) (router.RoutingTable, error) {
+	flatH := h.(types.Handshake)
+	return NewTable(flatH.GetKnown()), nil
+}
+
+// Table is an empty routing table. We don't need one since we are using direct
+// routing.
+//
+// - implements router.RoutingTable
+type Table struct {
+	known []mino.Address
+}
+
+// NewTable creates a new routing table
+func NewTable(addrs []mino.Address) Table {
+	return Table{
+		known: addrs,
+	}
+}
+
+// Make implements router.RoutingTable. It creates a packet with the source
+// address, the destination addresses and the payload.
+func (t Table) Make(src mino.Address, to []mino.Address, msg []byte) router.Packet {
+	return types.NewPacket(src, msg, to...)
+}
+
+// PrepareHandshakeFor implements router.RoutingTable. It creates a handshake
+// message that should be sent to the distant peer when opening a relay to it.
+// The peer will then generate its own routing table based on the handshake.
+func (t Table) PrepareHandshakeFor(to mino.Address) router.Handshake {
+	return types.NewHandshake(t.known...)
+}
+
+// Forward implements router.RoutingTable. It takes a packet and split it into
+// the different routes it should be forwarded to.
+func (t Table) Forward(packet router.Packet) (router.Routes, router.Voids) {
+	routes := make(router.Routes)
+	voids := make(router.Voids)
+
+	for _, dest := range packet.GetDestination() {
+
+		var gateway mino.Address
+
+		// check that we know the destination address, otherwise the gateway is
+		// nil.
+		for _, addr := range t.known {
+			if dest.Equal(addr) {
+				gateway = dest
+				break
+			}
+		}
+
+		p, ok := routes[gateway]
+		if !ok {
+			p = types.NewPacket(packet.GetSource(), packet.GetMessage())
+			routes[gateway] = p
+		}
+
+		p.(*types.Packet).Add(dest)
+	}
+
+	return routes, voids
+}
+
+// OnFailure implements router.Router. The tree will try to adapt itself to
+// reach the address, but it will return an error if the address is a direct
+// branch of the tree.
+func (t Table) OnFailure(to mino.Address) error {
+	return xerrors.New("flat routing has no alternatives")
+}

--- a/mino/router/flat/mod_test.go
+++ b/mino/router/flat/mod_test.go
@@ -1,0 +1,85 @@
+package flat
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.dedis.ch/dela/internal/testing/fake"
+	"go.dedis.ch/dela/mino"
+	"go.dedis.ch/dela/mino/router/flat/types"
+)
+
+func TestRouter_New(t *testing.T) {
+	router := NewRouter(fake.AddressFactory{})
+	addrs := makeAddrs(10)
+
+	_, err := router.New(mino.NewAddresses(addrs...), addrs[0])
+	require.NoError(t, err)
+}
+
+func TestRouter_GetPacketFactory(t *testing.T) {
+	router := NewRouter(fake.AddressFactory{})
+
+	require.NotNil(t, router.GetPacketFactory())
+}
+
+func TestRouter_GetHandshakeFactory(t *testing.T) {
+	router := NewRouter(fake.AddressFactory{})
+
+	require.NotNil(t, router.GetHandshakeFactory())
+}
+
+func TestRouter_GenerateTableFrom(t *testing.T) {
+	router := NewRouter(fake.AddressFactory{})
+
+	hs := types.NewHandshake(makeAddrs(5)...)
+	table, err := router.GenerateTableFrom(hs)
+	require.NoError(t, err)
+	require.NotNil(t, table)
+}
+
+func TestTable_Make(t *testing.T) {
+	table := NewTable(makeAddrs(5))
+
+	pkt := table.Make(fake.NewAddress(0), makeAddrs(3), []byte{1, 2, 3})
+	require.NotNil(t, pkt)
+	require.Equal(t, fake.NewAddress(0), pkt.GetSource())
+	require.Len(t, pkt.GetDestination(), 3)
+	require.Equal(t, []byte{1, 2, 3}, pkt.GetMessage())
+}
+
+func TestTable_PrepareHandshakeFor(t *testing.T) {
+	addrs := makeAddrs(5)
+	table := NewTable(addrs)
+
+	hs := table.PrepareHandshakeFor(fake.NewAddress(1))
+	require.Equal(t, addrs, hs.(types.Handshake).GetKnown())
+}
+
+func TestTable_Forward(t *testing.T) {
+	table := NewTable(makeAddrs(20))
+
+	pkt := types.NewPacket(fake.NewAddress(0), []byte{1, 2, 3}, makeAddrs(20)...)
+
+	routes, voids := table.Forward(pkt)
+	require.Len(t, voids, 0)
+	require.Len(t, routes, 20)
+}
+
+func TestTable_OnFailure(t *testing.T) {
+	table := NewTable(makeAddrs(5))
+	err := table.OnFailure(fake.NewAddress(3))
+	require.EqualError(t, err, "flat routing has no alternatives")
+}
+
+// -----------------------------------------------------------------------------
+// Utility functions
+
+func makeAddrs(n int) []mino.Address {
+	addrs := make([]mino.Address, n)
+	for i := range addrs {
+		addrs[i] = fake.NewAddress(i)
+	}
+
+	return addrs
+}

--- a/mino/router/flat/types/handshake.go
+++ b/mino/router/flat/types/handshake.go
@@ -1,0 +1,88 @@
+// The file contains the implementation of a handshake message that is sent to
+// create the routing table.
+//
+
+package types
+
+import (
+	"go.dedis.ch/dela/mino"
+	"go.dedis.ch/dela/mino/router"
+	"go.dedis.ch/dela/serde"
+	"go.dedis.ch/dela/serde/registry"
+	"golang.org/x/xerrors"
+)
+
+var hsFormats = registry.NewSimpleRegistry()
+
+// Handshake is a message to send the initial parameters of a routing table.
+//
+// - implements serde.Message
+type Handshake struct {
+	known []mino.Address
+}
+
+// NewHandshake returns a new handshake message.
+func NewHandshake(known ...mino.Address) Handshake {
+	return Handshake{
+		known: known,
+	}
+}
+
+// GetKnown returns the known addresses
+func (h Handshake) GetKnown() []mino.Address {
+	return h.known
+}
+
+// Serialize implements serde.Message. It returns the serialized data for the
+// handshake.
+func (h Handshake) Serialize(ctx serde.Context) ([]byte, error) {
+	format := hsFormats.Get(ctx.GetFormat())
+
+	data, err := format.Encode(ctx, h)
+	if err != nil {
+		return nil, xerrors.Errorf("encode: %v", err)
+	}
+
+	return data, nil
+}
+
+// HandshakeFactory is a factory to serialize and deserialize handshake
+// messages.
+//
+// - implements router.HandshakeFactory
+type HandshakeFactory struct {
+	addrFac mino.AddressFactory
+}
+
+// NewHandshakeFactory creates a new factory.
+func NewHandshakeFactory(addrFac mino.AddressFactory) HandshakeFactory {
+	return HandshakeFactory{
+		addrFac: addrFac,
+	}
+}
+
+// Deserialize implements serde.Factory. It populates the handshake if
+// appropriate, otherwise it returns an error.
+func (fac HandshakeFactory) Deserialize(ctx serde.Context, data []byte) (serde.Message, error) {
+	return fac.HandshakeOf(ctx, data)
+}
+
+// HandshakeOf implements router.HandshakeFactory. It populates the handshake if
+// appropriate, otherwise it returns an error.
+func (fac HandshakeFactory) HandshakeOf(ctx serde.Context, data []byte) (router.Handshake, error) {
+	format := hsFormats.Get(ctx.GetFormat())
+
+	ctx = serde.WithFactory(ctx, AddrKey{}, fac.addrFac)
+
+	msg, err := format.Decode(ctx, data)
+	if err != nil {
+		return nil, xerrors.Errorf("decode: %v", err)
+	}
+
+	hs, ok := msg.(Handshake)
+	if !ok {
+		return nil, xerrors.Errorf("invalid handshake '%T'", msg)
+	}
+
+	return hs, nil
+}

--- a/mino/router/flat/types/handshake_test.go
+++ b/mino/router/flat/types/handshake_test.go
@@ -1,0 +1,60 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.dedis.ch/dela/internal/testing/fake"
+	"go.dedis.ch/dela/mino"
+)
+
+func init() {
+	RegisterHandshakeFormat(fake.GoodFormat, fake.Format{Msg: Handshake{}})
+	RegisterHandshakeFormat(fake.BadFormat, fake.NewBadFormat())
+	RegisterHandshakeFormat(fake.MsgFormat, fake.NewMsgFormat())
+}
+
+func TestHandshake_GetKnown(t *testing.T) {
+	hs := NewHandshake(makeAddrs(5)...)
+
+	require.Len(t, hs.GetKnown(), 5)
+}
+
+func TestHandshake_Serialize(t *testing.T) {
+	hs := NewHandshake(makeAddrs(5)...)
+
+	ctx := fake.NewContext()
+
+	data, err := hs.Serialize(ctx)
+	require.NoError(t, err)
+	require.Equal(t, fake.GetFakeFormatValue(), data)
+
+	_, err = hs.Serialize(fake.NewBadContext())
+	require.EqualError(t, err, fake.Err("encode"))
+}
+
+func TestHandshakeFactory_Deserialize(t *testing.T) {
+	fac := NewHandshakeFactory(fake.AddressFactory{})
+
+	msg, err := fac.Deserialize(fake.NewContext(), nil)
+	require.NoError(t, err)
+	require.Equal(t, Handshake{}, msg)
+
+	_, err = fac.Deserialize(fake.NewBadContext(), nil)
+	require.EqualError(t, err, fake.Err("decode"))
+
+	_, err = fac.Deserialize(fake.NewMsgContext(), nil)
+	require.EqualError(t, err, "invalid handshake 'fake.Message'")
+}
+
+// -----------------------------------------------------------------------------
+// Utility functions
+
+func makeAddrs(n int) []mino.Address {
+	addrs := make([]mino.Address, n)
+	for i := range addrs {
+		addrs[i] = fake.NewAddress(i)
+	}
+
+	return addrs
+}

--- a/mino/router/flat/types/mod.go
+++ b/mino/router/flat/types/mod.go
@@ -1,0 +1,19 @@
+// Package types implements the packet and handshake messages for the flat
+// routing algorithm.
+//
+// The messages have been implemented in this isolated package so that it does
+// not create cycle imports when importing the serde formats.
+//
+package types
+
+import "go.dedis.ch/dela/serde"
+
+// RegisterHandshakeFormat registers the engine for the provided format.
+func RegisterHandshakeFormat(f serde.Format, e serde.FormatEngine) {
+	hsFormats.Register(f, e)
+}
+
+// RegisterPacketFormat registers the engine for the provided format.
+func RegisterPacketFormat(c serde.Format, f serde.FormatEngine) {
+	packetFormat.Register(c, f)
+}

--- a/mino/router/flat/types/packet.go
+++ b/mino/router/flat/types/packet.go
@@ -1,0 +1,142 @@
+// This file contains the implementation of the packet message.
+
+package types
+
+import (
+	"go.dedis.ch/dela/mino"
+	"go.dedis.ch/dela/mino/router"
+	"go.dedis.ch/dela/serde"
+	"go.dedis.ch/dela/serde/registry"
+	"golang.org/x/xerrors"
+)
+
+var packetFormat = registry.NewSimpleRegistry()
+
+// Packet describes a flat routing packet
+//
+// - implements router.Packet
+type Packet struct {
+	src  mino.Address
+	dest []mino.Address
+	msg  []byte
+}
+
+// NewPacket creates a new packet.
+func NewPacket(src mino.Address, msg []byte, dest ...mino.Address) *Packet {
+	return &Packet{
+		src:  src,
+		dest: dest,
+		msg:  msg,
+	}
+}
+
+// GetSource implements router.Packet. It returns the source address of the
+// packet.
+func (p *Packet) GetSource() mino.Address {
+	return p.src
+}
+
+// GetDestination implements router.Packet. It returns a list of addresses where
+// the packet should be send to.
+func (p *Packet) GetDestination() []mino.Address {
+	return append([]mino.Address{}, p.dest...)
+}
+
+// GetMessage implements router.Packet. It returns the byte buffer of the
+// message.
+func (p *Packet) GetMessage() []byte {
+	return append([]byte{}, p.msg...)
+}
+
+// Add appends the address to the destination list, only if it does not exist
+// already.
+func (p *Packet) Add(to mino.Address) {
+	for _, addr := range p.dest {
+		if addr.Equal(to) {
+			return
+		}
+	}
+
+	p.dest = append(p.dest, to)
+}
+
+// Slice implements router.Packet. It removes the address from the destination
+// list and returns a packet with this single destination, if it exists.
+// Otherwise the packet stays unchanged.
+func (p *Packet) Slice(addr mino.Address) router.Packet {
+	removed := false
+
+	// in reverse order to remove from the slice "in place"
+	for i := len(p.dest) - 1; i >= 0; i-- {
+		if p.dest[i].Equal(addr) {
+			p.dest = append(p.dest[:i], p.dest[i+1:]...)
+			removed = true
+		}
+	}
+
+	if !removed {
+		return nil
+	}
+
+	return &Packet{
+		src:  p.src,
+		dest: []mino.Address{addr},
+		msg:  p.msg,
+	}
+}
+
+// Serialize implements serde.Message. It returns the serialized data of the
+// packet.
+func (p *Packet) Serialize(ctx serde.Context) ([]byte, error) {
+	format := packetFormat.Get(ctx.GetFormat())
+
+	data, err := format.Encode(ctx, p)
+	if err != nil {
+		return nil, xerrors.Errorf("packet format: %v", err)
+	}
+
+	return data, nil
+}
+
+// AddrKey is the key for the address factory.
+type AddrKey struct{}
+
+// PacketFactory is a factory for the packet.
+//
+// - implements serde.Factory
+type PacketFactory struct {
+	addrFactory mino.AddressFactory
+}
+
+// NewPacketFactory returns a factory for the packet.
+func NewPacketFactory(f mino.AddressFactory) PacketFactory {
+	return PacketFactory{
+		addrFactory: f,
+	}
+}
+
+// PacketOf implements router.PacketFactory. It populates the packet associated
+// with the data if appropriate, otherwise it returns an error.
+func (f PacketFactory) PacketOf(ctx serde.Context, data []byte) (router.Packet, error) {
+	format := packetFormat.Get(ctx.GetFormat())
+
+	ctx = serde.WithFactory(ctx, AddrKey{}, f.addrFactory)
+
+	msg, err := format.Decode(ctx, data)
+	if err != nil {
+		return nil, xerrors.Errorf("packet format: %v", err)
+	}
+
+	packet, ok := msg.(*Packet)
+	if !ok {
+		return nil, xerrors.Errorf("invalid packet '%T'", msg)
+	}
+
+	return packet, nil
+}
+
+// Deserialize implements serde.Factory. It populates the packet associated
+// with the data if appropriate, otherwise it returns an error.
+func (f PacketFactory) Deserialize(ctx serde.Context, data []byte) (serde.Message, error) {
+	return f.PacketOf(ctx, data)
+}

--- a/mino/router/flat/types/packet_test.go
+++ b/mino/router/flat/types/packet_test.go
@@ -1,0 +1,83 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.dedis.ch/dela/internal/testing/fake"
+	"go.dedis.ch/dela/mino"
+)
+
+func init() {
+	RegisterPacketFormat(fake.GoodFormat, fake.Format{Msg: &Packet{}})
+	RegisterPacketFormat(fake.BadFormat, fake.NewBadFormat())
+	RegisterPacketFormat(fake.MsgFormat, fake.NewMsgFormat())
+}
+
+func TestPacket_GetSource(t *testing.T) {
+	pkt := NewPacket(fake.NewAddress(0), nil)
+
+	require.Equal(t, fake.NewAddress(0), pkt.GetSource())
+}
+
+func TestPacket_GetDestination(t *testing.T) {
+	pkt := NewPacket(fake.NewAddress(0), nil, makeAddrs(5)...)
+
+	require.Len(t, pkt.GetDestination(), 5)
+}
+
+func TestPacket_GetMessage(t *testing.T) {
+	pkt := NewPacket(fake.NewAddress(0), []byte{1, 2, 3})
+
+	require.Equal(t, []byte{1, 2, 3}, pkt.GetMessage())
+}
+
+func TestPacket_Add(t *testing.T) {
+	pkt := NewPacket(fake.NewAddress(0), nil)
+	require.Len(t, pkt.dest, 0)
+
+	pkt.Add(fake.NewAddress(0))
+	require.Len(t, pkt.dest, 1)
+
+	pkt.Add(fake.NewAddress(0))
+	require.Len(t, pkt.dest, 1)
+
+	pkt.Add(fake.NewAddress(1))
+	require.Len(t, pkt.dest, 2)
+}
+
+func TestPacket_Slice(t *testing.T) {
+	pkt := NewPacket(fake.NewAddress(0), []byte{0xaa}, makeAddrs(10)...)
+
+	newPkt := pkt.Slice(fake.NewAddress(500))
+	require.Nil(t, newPkt)
+
+	newPkt = pkt.Slice(fake.NewAddress(6))
+	require.Equal(t, []mino.Address{fake.NewAddress(6)}, newPkt.GetDestination())
+	require.Len(t, pkt.dest, 9)
+}
+
+func TestPacket_Serialize(t *testing.T) {
+	pkt := NewPacket(fake.NewAddress(0), nil)
+
+	data, err := pkt.Serialize(fake.NewContext())
+	require.NoError(t, err)
+	require.Equal(t, fake.GetFakeFormatValue(), data)
+
+	_, err = pkt.Serialize(fake.NewBadContext())
+	require.EqualError(t, err, fake.Err("packet format"))
+}
+
+func TestPacketFactory_Deserialize(t *testing.T) {
+	fac := NewPacketFactory(fake.AddressFactory{})
+
+	msg, err := fac.Deserialize(fake.NewContext(), nil)
+	require.NoError(t, err)
+	require.Equal(t, &Packet{}, msg)
+
+	_, err = fac.Deserialize(fake.NewBadContext(), nil)
+	require.EqualError(t, err, fake.Err("packet format"))
+
+	_, err = fac.Deserialize(fake.NewMsgContext(), nil)
+	require.EqualError(t, err, "invalid packet 'fake.Message'")
+}

--- a/mino/router/mod.go
+++ b/mino/router/mod.go
@@ -74,7 +74,10 @@ type Router interface {
 	GenerateTableFrom(Handshake) (RoutingTable, error)
 }
 
-// Routes is a set of relay addresses where to send the packet.
+// Routes is a set of relay addresses where to send the packet. Key is the relay
+// address. It can be nil, and in that case minogrpc sends the message to its
+// parent relay. This is the case when the destination address is the
+// orchestrator address.
 type Routes map[mino.Address]Packet
 
 // Void is the structure that describes a void route.

--- a/serde/json/mod.go
+++ b/serde/json/mod.go
@@ -20,6 +20,7 @@ import (
 	_ "go.dedis.ch/dela/crypto/bls/json"
 	_ "go.dedis.ch/dela/crypto/ed25519/json"
 	_ "go.dedis.ch/dela/dkg/pedersen/json"
+	_ "go.dedis.ch/dela/mino/router/flat/json"
 	_ "go.dedis.ch/dela/mino/router/tree/json"
 	"go.dedis.ch/dela/serde"
 )


### PR DESCRIPTION
This flat routing implementation assumes a N-N connectivity among nodes. It brings more stability on a small topology, as failing tree nodes can break communications.

This is basically a simplified copy of the tree routing implementation.

Also updates `memcoin` to use by default the flat routing. A new flag `routing` can specify either `flat` (default) or `tree`.