### PR TITLE
Adds insecure mode on minogrpc

### DIFF
--- a/internal/testing/fake/tracing.go
+++ b/internal/testing/fake/tracing.go
@@ -9,7 +9,7 @@ func GetTracerForAddrWithError(addr string) (opentracing.Tracer, error) {
 }
 
 // GetTracerForAddrEmpty is used to mock `tracing.GetTracerForAddr` with an
-// error.
+// empty tracer.
 func GetTracerForAddrEmpty(_ string) (opentracing.Tracer, error) {
 	return opentracing.NoopTracer{}, nil
 }

--- a/internal/testing/fake/tracing.go
+++ b/internal/testing/fake/tracing.go
@@ -2,7 +2,14 @@ package fake
 
 import opentracing "github.com/opentracing/opentracing-go"
 
-// GetTracerForAddr is used to mock `tracing.GetTracerForAddr` with an error.
+// GetTracerForAddrWithError is used to mock `tracing.GetTracerForAddr` with an
+// error.
 func GetTracerForAddrWithError(addr string) (opentracing.Tracer, error) {
 	return nil, fakeErr
+}
+
+// GetTracerForAddrEmpty is used to mock `tracing.GetTracerForAddr` with an
+// error.
+func GetTracerForAddrEmpty(_ string) (opentracing.Tracer, error) {
+	return opentracing.NoopTracer{}, nil
 }

--- a/mino/minogrpc/controller/actions_test.go
+++ b/mino/minogrpc/controller/actions_test.go
@@ -280,6 +280,7 @@ type fakeContext struct {
 	str      map[string]string
 	path     map[string]string
 	num      int
+	boolean  bool
 }
 
 func (ctx fakeContext) Duration(string) time.Duration {
@@ -296,6 +297,10 @@ func (ctx fakeContext) Path(key string) string {
 
 func (ctx fakeContext) Int(string) int {
 	return ctx.num
+}
+
+func (ctx fakeContext) Bool(string) bool {
+	return ctx.boolean
 }
 
 type badCertStore struct {

--- a/mino/minogrpc/mod.go
+++ b/mino/minogrpc/mod.go
@@ -118,15 +118,16 @@ type Minogrpc struct {
 }
 
 type minoTemplate struct {
-	myAddr session.Address
-	router router.Router
-	fac    mino.AddressFactory
-	certs  certs.Storage
-	secret interface{}
-	public interface{}
-	curve  elliptic.Curve
-	random io.Reader
-	cert   *tls.Certificate
+	myAddr   session.Address
+	router   router.Router
+	fac      mino.AddressFactory
+	certs    certs.Storage
+	secret   interface{}
+	public   interface{}
+	curve    elliptic.Curve
+	random   io.Reader
+	cert     *tls.Certificate
+	insecure bool
 }
 
 // Option is the type to set some fields when instantiating an overlay.
@@ -163,6 +164,14 @@ func WithCert(cert *tls.Certificate) Option {
 	}
 }
 
+// DisableTLS disables TLS encryption on gRPC connections. It takes precedence
+// over WithCert.
+func DisableTLS() Option {
+	return func(tmpl *minoTemplate) {
+		tmpl.insecure = true
+	}
+}
+
 // NewMinogrpc creates and starts a new instance. it will try to listen for the
 // address and returns an error if it fails. "listen" is the local address,
 // while "public" is the public node address. If public is empty it uses the
@@ -184,12 +193,13 @@ func NewMinogrpc(listen net.Addr, public *url.URL, router router.Router, opts ..
 	dela.Logger.Info().Msgf("public URL is: %s", public.String())
 
 	tmpl := minoTemplate{
-		myAddr: session.NewAddress(public.Host + public.Path),
-		router: router,
-		fac:    addressFac,
-		certs:  certs.NewInMemoryStore(),
-		curve:  elliptic.P521(),
-		random: rand.Reader,
+		myAddr:   session.NewAddress(public.Host + public.Path),
+		router:   router,
+		fac:      addressFac,
+		certs:    certs.NewInMemoryStore(),
+		curve:    elliptic.P521(),
+		random:   rand.Reader,
+		insecure: false,
 	}
 
 	for _, opt := range opts {
@@ -202,38 +212,44 @@ func NewMinogrpc(listen net.Addr, public *url.URL, router router.Router, opts ..
 		return nil, xerrors.Errorf("overlay: %v", err)
 	}
 
-	chainBuf := o.GetCertificateChain()
-	certs, err := x509.ParseCertificates(chainBuf)
-	if err != nil {
-		socket.Close()
-		return nil, xerrors.Errorf("failed to parse chain: %v", err)
-	}
-
-	certsBuf := make([][]byte, len(certs))
-	for i, c := range certs {
-		certsBuf[i] = c.Raw
-	}
-
-	creds := credentials.NewTLS(&tls.Config{
-		Certificates: []tls.Certificate{{
-			Certificate: certsBuf,
-			Leaf:        certs[0],
-			PrivateKey:  o.secret,
-		}},
-		MinVersion: tls.VersionTLS12,
-	})
-
 	dialAddr := o.myAddr.GetDialAddress()
 	tracer, err := getTracerForAddr(dialAddr)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to get tracer for addr %s: %v", dialAddr, err)
 	}
 
-	server := grpc.NewServer(
-		grpc.Creds(creds),
+	srvOpts := []grpc.ServerOption{
 		grpc.UnaryInterceptor(otgrpc.OpenTracingServerInterceptor(tracer, otgrpc.SpanDecorator(decorateServerTrace))),
 		grpc.StreamInterceptor(otgrpc.OpenTracingStreamServerInterceptor(tracer, otgrpc.SpanDecorator(decorateServerTrace))),
-	)
+	}
+
+	if !tmpl.insecure {
+		chainBuf := o.GetCertificateChain()
+		certs, err := x509.ParseCertificates(chainBuf)
+		if err != nil {
+			socket.Close()
+			return nil, xerrors.Errorf("failed to parse chain: %v", err)
+		}
+
+		certsBuf := make([][]byte, len(certs))
+		for i, c := range certs {
+			certsBuf[i] = c.Raw
+		}
+
+		creds := credentials.NewTLS(&tls.Config{
+			Certificates: []tls.Certificate{{
+				Certificate: certsBuf,
+				Leaf:        certs[0],
+				PrivateKey:  o.secret,
+			}},
+			MinVersion: tls.VersionTLS12,
+		})
+
+		srvOpts = append(srvOpts, grpc.Creds(creds))
+
+	}
+
+	server := grpc.NewServer(srvOpts...)
 
 	m := &Minogrpc{
 		overlay:   o,

--- a/mino/minogrpc/mod.go
+++ b/mino/minogrpc/mod.go
@@ -246,7 +246,9 @@ func NewMinogrpc(listen net.Addr, public *url.URL, router router.Router, opts ..
 		})
 
 		srvOpts = append(srvOpts, grpc.Creds(creds))
-
+	} else {
+		dela.Logger.Warn().Msg("⚠️ running in insecure mode, you should not " +
+			"publicly expose the node's socket")
 	}
 
 	server := grpc.NewServer(srvOpts...)

--- a/mino/minogrpc/mod_test.go
+++ b/mino/minogrpc/mod_test.go
@@ -36,6 +36,25 @@ func TestMinogrpc_New(t *testing.T) {
 	require.NoError(t, m.GracefulStop())
 }
 
+func TestMinogrpc_insecure(t *testing.T) {
+	addr := ParseAddress("127.0.0.1", 3333)
+
+	router := tree.NewRouter(addressFac)
+
+	m, err := NewMinogrpc(addr, nil, router, DisableTLS())
+	require.NoError(t, err)
+
+	require.Equal(t, "127.0.0.1:3333", m.GetAddress().String())
+	require.Empty(t, m.segments)
+
+	cert, err := m.certs.Load(m.GetAddress())
+	require.NoError(t, err)
+	require.Nil(t, cert)
+
+	<-m.started
+	require.NoError(t, m.GracefulStop())
+}
+
 func TestMinogrpc_New_FailedParsePublic(t *testing.T) {
 	l := listener
 	defer func() {

--- a/mino/minogrpc/mod_test.go
+++ b/mino/minogrpc/mod_test.go
@@ -36,7 +36,7 @@ func TestMinogrpc_New(t *testing.T) {
 	require.NoError(t, m.GracefulStop())
 }
 
-func TestMinogrpc_insecure(t *testing.T) {
+func TestMinogrpc_noTLS(t *testing.T) {
 	addr := ParseAddress("127.0.0.1", 3333)
 
 	router := tree.NewRouter(addressFac)

--- a/mino/minogrpc/server.go
+++ b/mino/minogrpc/server.go
@@ -16,12 +16,13 @@ import (
 	"crypto/x509"
 	"sync"
 
-	otgrpc "github.com/opentracing-contrib/go-grpc"
-	"github.com/opentracing/opentracing-go"
 	"math/big"
 	"net"
 	"net/url"
 	"time"
+
+	otgrpc "github.com/opentracing-contrib/go-grpc"
+	"github.com/opentracing/opentracing-go"
 
 	"go.dedis.ch/dela"
 	"go.dedis.ch/dela/internal/tracing"
@@ -37,6 +38,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/backoff"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -449,14 +451,14 @@ func newOverlay(tmpl *minoTemplate) (*overlay, error) {
 	// session.Address never returns an error
 	myAddrBuf, _ := tmpl.myAddr.MarshalText()
 
-	if tmpl.cert != nil {
+	if tmpl.cert != nil && !tmpl.insecure {
 		tmpl.secret = tmpl.cert.PrivateKey
 		// it is okay to crash at this point, as the certificate's key is
 		// invalid
 		tmpl.public = tmpl.cert.PrivateKey.(interface{ Public() crypto.PublicKey }).Public()
 	}
 
-	if tmpl.secret == nil {
+	if tmpl.secret == nil && !tmpl.insecure {
 		priv, err := ecdsa.GenerateKey(tmpl.curve, tmpl.random)
 		if err != nil {
 			return nil, xerrors.Errorf("cert private key: %v", err)
@@ -474,13 +476,13 @@ func newOverlay(tmpl *minoTemplate) (*overlay, error) {
 		tokens:      tokens.NewInMemoryHolder(),
 		certs:       tmpl.certs,
 		router:      tmpl.router,
-		connMgr:     newConnManager(tmpl.myAddr, tmpl.certs),
+		connMgr:     newConnManager(tmpl.myAddr, tmpl.certs, tmpl.insecure),
 		addrFactory: tmpl.fac,
 		secret:      tmpl.secret,
 		public:      tmpl.public,
 	}
 
-	if tmpl.cert != nil {
+	if tmpl.cert != nil && !tmpl.insecure {
 		chain := bytes.Buffer{}
 		for _, c := range tmpl.cert.Certificate {
 			chain.Write(c)
@@ -492,15 +494,17 @@ func newOverlay(tmpl *minoTemplate) (*overlay, error) {
 		}
 	}
 
-	cert, err := o.certs.Load(o.myAddr)
-	if err != nil {
-		return nil, xerrors.Errorf("while loading cert: %v", err)
-	}
-
-	if cert == nil {
-		err = o.makeCertificate()
+	if !tmpl.insecure {
+		cert, err := o.certs.Load(o.myAddr)
 		if err != nil {
-			return nil, xerrors.Errorf("certificate failed: %v", err)
+			return nil, xerrors.Errorf("while loading cert: %v", err)
+		}
+
+		if cert == nil {
+			err = o.makeCertificate()
+			if err != nil {
+				return nil, xerrors.Errorf("certificate failed: %v", err)
+			}
 		}
 	}
 
@@ -508,7 +512,7 @@ func newOverlay(tmpl *minoTemplate) (*overlay, error) {
 }
 
 // GetCertificate returns the certificate of the overlay with its private key
-// set.
+// set. This function will panic if the overlay is not using TLS.
 func (o *overlay) GetCertificateChain() certs.CertChain {
 	me, err := o.certs.Load(o.myAddr)
 	if err != nil {
@@ -638,14 +642,16 @@ type connManager struct {
 	myAddr   mino.Address
 	counters map[mino.Address]int
 	conns    map[mino.Address]*grpc.ClientConn
+	insecure bool
 }
 
-func newConnManager(myAddr mino.Address, certs certs.Storage) *connManager {
+func newConnManager(myAddr mino.Address, certs certs.Storage, insecure bool) *connManager {
 	return &connManager{
 		certs:    certs,
 		myAddr:   myAddr,
 		counters: make(map[mino.Address]int),
 		conns:    make(map[mino.Address]*grpc.ClientConn),
+		insecure: insecure,
 	}
 }
 
@@ -670,11 +676,6 @@ func (mgr *connManager) Acquire(to mino.Address) (grpc.ClientConnInterface, erro
 		return conn, nil
 	}
 
-	ta, err := mgr.getTransportCredential(to)
-	if err != nil {
-		return nil, xerrors.Errorf("failed to retrieve transport credential: %v", err)
-	}
-
 	netAddr, ok := to.(session.Address)
 	if !ok {
 		return nil, xerrors.Errorf("invalid address type '%T'", to)
@@ -690,10 +691,7 @@ func (mgr *connManager) Acquire(to mino.Address) (grpc.ClientConnInterface, erro
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(2)*time.Second)
 	defer cancel()
 
-	conn, err = grpc.DialContext(
-		ctx,
-		addr,
-		grpc.WithTransportCredentials(ta),
+	opts := []grpc.DialOption{
 		grpc.WithConnectParams(grpc.ConnectParams{
 			Backoff:           backoff.DefaultConfig,
 			MinConnectTimeout: defaultMinConnectTimeout,
@@ -704,6 +702,22 @@ func (mgr *connManager) Acquire(to mino.Address) (grpc.ClientConnInterface, erro
 		grpc.WithStreamInterceptor(
 			otgrpc.OpenTracingStreamClientInterceptor(tracer, otgrpc.SpanDecorator(decorateClientTrace)),
 		),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	}
+
+	if !mgr.insecure {
+		ta, err := mgr.getTransportCredential(to)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to retrieve transport credential: %v", err)
+		}
+
+		opts = append(opts, grpc.WithTransportCredentials(ta))
+	}
+
+	conn, err = grpc.DialContext(
+		ctx,
+		addr,
+		opts...,
 	)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to dial: %v", err)

--- a/mino/minogrpc/server_test.go
+++ b/mino/minogrpc/server_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/stretchr/testify/require"
 	"go.dedis.ch/dela/internal/testing/fake"
 	"go.dedis.ch/dela/internal/tracing"
@@ -184,6 +185,7 @@ func TestOverlayServer_Join(t *testing.T) {
 		router: tree.NewRouter(addressFac),
 		curve:  elliptic.P521(),
 		random: rand.Reader,
+		useTLS: true,
 	})
 	require.NoError(t, err)
 
@@ -766,6 +768,7 @@ func TestOverlay_New(t *testing.T) {
 		certs:  certs.NewInMemoryStore(),
 		curve:  elliptic.P521(),
 		random: rand.Reader,
+		useTLS: true,
 	})
 	require.NoError(t, err)
 
@@ -780,6 +783,7 @@ func TestOverlay_New_Hostname(t *testing.T) {
 		certs:  certs.NewInMemoryStore(),
 		curve:  elliptic.P521(),
 		random: rand.Reader,
+		useTLS: true,
 	})
 	require.NoError(t, err)
 
@@ -796,6 +800,7 @@ func TestOverlay_New_Wrong_Cert_Store(t *testing.T) {
 		certs:  fakeCerts{errStore: fake.GetError()},
 		curve:  elliptic.P521(),
 		random: rand.Reader,
+		useTLS: true,
 	})
 	require.EqualError(t, err, fake.Err("failed to store cert"))
 }
@@ -834,6 +839,7 @@ func TestOverlay_Join(t *testing.T) {
 		fac:    addressFac,
 		curve:  elliptic.P521(),
 		random: rand.Reader,
+		useTLS: true,
 	})
 	require.NoError(t, err)
 
@@ -900,13 +906,10 @@ func TestConnManager_Acquire(t *testing.T) {
 }
 
 func TestConnManager_FailLoadDistantCert_Acquire(t *testing.T) {
-	oldGetter := getTracerForAddr
-	defer func() {
-		getTracerForAddr = oldGetter
-	}()
+	defer revertGetTracer(getTracerForAddr)
 	getTracerForAddr = fake.GetTracerForAddrEmpty
 
-	mgr := newConnManager(fake.NewAddress(0), certs.NewInMemoryStore(), false)
+	mgr := newConnManager(fake.NewAddress(0), certs.NewInMemoryStore(), true)
 	mgr.certs = fakeCerts{errLoad: fake.GetError()}
 
 	_, err := mgr.Acquire(session.Address{})
@@ -914,13 +917,10 @@ func TestConnManager_FailLoadDistantCert_Acquire(t *testing.T) {
 }
 
 func TestConnManager_MissingCert_Acquire(t *testing.T) {
-	oldGetter := getTracerForAddr
-	defer func() {
-		getTracerForAddr = oldGetter
-	}()
+	defer revertGetTracer(getTracerForAddr)
 	getTracerForAddr = fake.GetTracerForAddrEmpty
 
-	mgr := newConnManager(fake.NewAddress(0), certs.NewInMemoryStore(), false)
+	mgr := newConnManager(fake.NewAddress(0), certs.NewInMemoryStore(), true)
 
 	to := session.NewAddress("fake")
 	_, err := mgr.Acquire(to)
@@ -928,13 +928,10 @@ func TestConnManager_MissingCert_Acquire(t *testing.T) {
 }
 
 func TestConnManager_FailLoadOwnCert_Acquire(t *testing.T) {
-	oldGetter := getTracerForAddr
-	defer func() {
-		getTracerForAddr = oldGetter
-	}()
+	defer revertGetTracer(getTracerForAddr)
 	getTracerForAddr = fake.GetTracerForAddrEmpty
 
-	mgr := newConnManager(fake.NewAddress(0), certs.NewInMemoryStore(), false)
+	mgr := newConnManager(fake.NewAddress(0), certs.NewInMemoryStore(), true)
 	mgr.certs = fakeCerts{
 		errLoad: fake.GetError(),
 		counter: fake.NewCounter(1),
@@ -945,13 +942,10 @@ func TestConnManager_FailLoadOwnCert_Acquire(t *testing.T) {
 }
 
 func TestConnManager_MissingOwnCert_Acquire(t *testing.T) {
-	oldGetter := getTracerForAddr
-	defer func() {
-		getTracerForAddr = oldGetter
-	}()
+	defer revertGetTracer(getTracerForAddr)
 	getTracerForAddr = fake.GetTracerForAddrEmpty
 
-	mgr := newConnManager(fake.NewAddress(0), certs.NewInMemoryStore(), false)
+	mgr := newConnManager(fake.NewAddress(0), certs.NewInMemoryStore(), true)
 
 	to := session.NewAddress("fake")
 	mgr.certs.Store(to, fake.MakeCertificate(t))
@@ -961,13 +955,10 @@ func TestConnManager_MissingOwnCert_Acquire(t *testing.T) {
 }
 
 func TestConnManager_BadDistantCert_Acquire(t *testing.T) {
-	oldGetter := getTracerForAddr
-	defer func() {
-		getTracerForAddr = oldGetter
-	}()
+	defer revertGetTracer(getTracerForAddr)
 	getTracerForAddr = fake.GetTracerForAddrEmpty
 
-	mgr := newConnManager(fake.NewAddress(0), certs.NewInMemoryStore(), false)
+	mgr := newConnManager(fake.NewAddress(0), certs.NewInMemoryStore(), true)
 	to := session.NewAddress("fake")
 
 	mgr.certs.Store(fake.NewAddress(0), fake.MakeCertificate(t))
@@ -978,13 +969,10 @@ func TestConnManager_BadDistantCert_Acquire(t *testing.T) {
 }
 
 func TestConnManager_BadOwnCert_Acquire(t *testing.T) {
-	oldGetter := getTracerForAddr
-	defer func() {
-		getTracerForAddr = oldGetter
-	}()
+	defer revertGetTracer(getTracerForAddr)
 	getTracerForAddr = fake.GetTracerForAddrEmpty
 
-	mgr := newConnManager(fake.NewAddress(0), certs.NewInMemoryStore(), false)
+	mgr := newConnManager(fake.NewAddress(0), certs.NewInMemoryStore(), true)
 	to := session.NewAddress("fake")
 
 	mgr.certs.Store(fake.NewAddress(0), certs.CertChain("bad chain"))
@@ -995,13 +983,10 @@ func TestConnManager_BadOwnCert_Acquire(t *testing.T) {
 }
 
 func TestConnManager_EmptyOwnCert_Acquire(t *testing.T) {
-	oldGetter := getTracerForAddr
-	defer func() {
-		getTracerForAddr = oldGetter
-	}()
+	defer revertGetTracer(getTracerForAddr)
 	getTracerForAddr = fake.GetTracerForAddrEmpty
 
-	mgr := newConnManager(fake.NewAddress(0), certs.NewInMemoryStore(), false)
+	mgr := newConnManager(fake.NewAddress(0), certs.NewInMemoryStore(), true)
 	to := session.NewAddress("fake")
 
 	mgr.certs.Store(fake.NewAddress(0), certs.CertChain{})
@@ -1012,7 +997,7 @@ func TestConnManager_EmptyOwnCert_Acquire(t *testing.T) {
 }
 
 func TestConnManager_BadAddress_Acquire(t *testing.T) {
-	mgr := newConnManager(fake.NewAddress(0), certs.NewInMemoryStore(), true)
+	mgr := newConnManager(fake.NewAddress(0), certs.NewInMemoryStore(), false)
 
 	mgr.certs.Store(fake.NewAddress(0), fake.MakeCertificate(t))
 
@@ -1028,7 +1013,7 @@ func TestConnManager_BadTracer_Acquire(t *testing.T) {
 
 	defer dst.GracefulStop()
 
-	mgr := newConnManager(fake.NewAddress(0), certs.NewInMemoryStore(), true)
+	mgr := newConnManager(fake.NewAddress(0), certs.NewInMemoryStore(), false)
 
 	getTracerForAddr = fake.GetTracerForAddrWithError
 
@@ -1199,4 +1184,8 @@ func (fakeSession) Listen(p session.Relay, t router.RoutingTable, c chan struct{
 
 func (fakeSession) RecvPacket(mino.Address, *ptypes.Packet) (*ptypes.Ack, error) {
 	return &ptypes.Ack{}, nil
+}
+
+func revertGetTracer(getTracer func(addr string) (opentracing.Tracer, error)) {
+	getTracerForAddr = getTracer
 }


### PR DESCRIPTION
Adds an option to disable TLS on gRPCs connections. This is only useful for testing purposes or when the node is behind a reverse-proxy. 