### PR TITLE
Optimizes some verification operations

### DIFF
--- a/core/ordering/cosipbft/blockstore/disk.go
+++ b/core/ordering/cosipbft/blockstore/disk.go
@@ -218,7 +218,7 @@ func (s *InDisk) GetChain() (types.Chain, error) {
 
 			link, err := s.fac.LinkOf(s.context, value)
 			if err != nil {
-				return xerrors.Errorf("block malformed: %v", err)
+				return xerrors.Errorf("link malformed: %v", err)
 			}
 
 			prevs[i] = link

--- a/core/ordering/cosipbft/blockstore/disk.go
+++ b/core/ordering/cosipbft/blockstore/disk.go
@@ -206,17 +206,22 @@ func (s *InDisk) GetChain() (types.Chain, error) {
 
 		i := uint64(0)
 		err := bucket.Scan([]byte{}, func(key, value []byte) error {
-			link, err := s.fac.BlockLinkOf(s.context, value)
-			if err != nil {
-				return xerrors.Errorf("block malformed: %v", err)
-			}
-
 			if i >= length-1 {
+				link, err := s.fac.BlockLinkOf(s.context, value)
+				if err != nil {
+					return xerrors.Errorf("block malformed: %v", err)
+				}
+
 				chain = types.NewChain(link, prevs)
 				return nil
 			}
 
-			prevs[i] = link.Reduce()
+			link, err := s.fac.LinkOf(s.context, value)
+			if err != nil {
+				return xerrors.Errorf("block malformed: %v", err)
+			}
+
+			prevs[i] = link
 			i++
 
 			return nil

--- a/core/ordering/cosipbft/blockstore/disk_test.go
+++ b/core/ordering/cosipbft/blockstore/disk_test.go
@@ -145,6 +145,20 @@ func TestInDisk_GetChain(t *testing.T) {
 
 	store.fac = badLinkFac{}
 	_, err = store.GetChain()
+	require.EqualError(t, err, fake.Err("while reading database: while scanning: link malformed"))
+}
+
+func TestInDisk_GetChain_BadBlockLink(t *testing.T) {
+	db, clean := makeDB(t)
+	defer clean()
+
+	store := NewDiskStore(db, makeBlockFac())
+
+	err := store.Store(makeLink(t, types.Digest{}, types.WithIndex(0)))
+	require.NoError(t, err)
+
+	store.fac = badLinkFac{}
+	_, err = store.GetChain()
 	require.EqualError(t, err, fake.Err("while reading database: while scanning: block malformed"))
 }
 

--- a/core/ordering/cosipbft/blockstore/disk_test.go
+++ b/core/ordering/cosipbft/blockstore/disk_test.go
@@ -264,6 +264,10 @@ func (badLinkFac) BlockLinkOf(serde.Context, []byte) (types.BlockLink, error) {
 	return nil, fake.GetError()
 }
 
+func (badLinkFac) LinkOf(serde.Context, []byte) (types.Link, error) {
+	return nil, fake.GetError()
+}
+
 type badLink struct {
 	types.BlockLink
 }

--- a/core/ordering/cosipbft/blocksync/default.go
+++ b/core/ordering/cosipbft/blocksync/default.go
@@ -240,7 +240,7 @@ func (h *handler) Stream(out mino.Sender, in mino.Receiver) error {
 	// have.
 	bl, err := h.blocks.Last()
 	if err == nil {
-		from = bl.GetHash()
+		from = bl.GetFrom()
 	}
 
 	err = m.GetChain().Verify(genesis, from, h.verifierFac)

--- a/core/ordering/cosipbft/blocksync/default.go
+++ b/core/ordering/cosipbft/blocksync/default.go
@@ -234,7 +234,16 @@ func (h *handler) Stream(out mino.Sender, in mino.Receiver) error {
 		return xerrors.Errorf("reading genesis: %v", err)
 	}
 
-	err = m.GetChain().Verify(genesis, h.verifierFac)
+	from := genesis.GetHash()
+
+	// We trust our storage, thus we won't check links on blocks we already
+	// have.
+	bl, err := h.blocks.Last()
+	if err == nil {
+		from = bl.GetHash()
+	}
+
+	err = m.GetChain().Verify(genesis, from, h.verifierFac)
 	if err != nil {
 		return xerrors.Errorf("failed to verify chain: %v", err)
 	}

--- a/core/ordering/cosipbft/blocksync/default_test.go
+++ b/core/ordering/cosipbft/blocksync/default_test.go
@@ -361,6 +361,6 @@ func (c fakeChain) GetBlock() otypes.Block {
 	return c.block
 }
 
-func (c fakeChain) Verify(otypes.Genesis, crypto.VerifierFactory) error {
+func (c fakeChain) Verify(otypes.Genesis, otypes.Digest, crypto.VerifierFactory) error {
 	return c.err
 }

--- a/core/ordering/cosipbft/controller/mod.go
+++ b/core/ordering/cosipbft/controller/mod.go
@@ -1,7 +1,6 @@
 // Package controller implements a minimal controller for cosipbft.
 //
 // Documentation Last Review: 13.10.2020
-//
 package controller
 
 import (

--- a/core/ordering/cosipbft/mod.go
+++ b/core/ordering/cosipbft/mod.go
@@ -27,7 +27,6 @@
 // https://www.usenix.org/system/files/conference/usenixsecurity16/sec16_paper_kokoris-kogias.pdf
 //
 // Documentation Last Review: 12.10.2020
-//
 package cosipbft
 
 import (

--- a/core/ordering/cosipbft/mod_test.go
+++ b/core/ordering/cosipbft/mod_test.go
@@ -130,10 +130,10 @@ func TestService_Scenario_ViewChange(t *testing.T) {
 // propagation failed.
 //
 // Expected log warnings and errors:
-//  - timeout from the followers
-//  - block not from the leader
-//  - round failed on node 0
-//  - mismatch state viewchange != (initial|prepare)
+//   - timeout from the followers
+//   - block not from the leader
+//   - round failed on node 0
+//   - mismatch state viewchange != (initial|prepare)
 func TestService_Scenario_FinalizeFailure(t *testing.T) {
 	nodes, ro, clean := makeAuthority(t, 4)
 	defer clean()

--- a/core/ordering/cosipbft/pbft/mod.go
+++ b/core/ordering/cosipbft/pbft/mod.go
@@ -11,7 +11,6 @@
 // proof of acceptance of the block.
 //
 // Documentation Last Review: 13.10.2020
-//
 package pbft
 
 import (

--- a/core/ordering/cosipbft/proof.go
+++ b/core/ordering/cosipbft/proof.go
@@ -40,9 +40,9 @@ func (p Proof) GetValue() []byte {
 }
 
 // Verify takes the genesis block and the verifier factory to verify the chain
-// up to the latest block.
+// up to the latest block. It verifies the whole chain.
 func (p Proof) Verify(genesis types.Genesis, fac crypto.VerifierFactory) error {
-	err := p.chain.Verify(genesis, fac)
+	err := p.chain.Verify(genesis, genesis.GetHash(), fac)
 	if err != nil {
 		return xerrors.Errorf("failed to verify chain: %v", err)
 	}

--- a/core/ordering/cosipbft/proof_test.go
+++ b/core/ordering/cosipbft/proof_test.go
@@ -80,6 +80,6 @@ func (c fakeChain) GetBlock() types.Block {
 	return c.block
 }
 
-func (c fakeChain) Verify(types.Genesis, crypto.VerifierFactory) error {
+func (c fakeChain) Verify(types.Genesis, types.Digest, crypto.VerifierFactory) error {
 	return c.err
 }

--- a/core/ordering/cosipbft/types/chain.go
+++ b/core/ordering/cosipbft/types/chain.go
@@ -335,6 +335,7 @@ func (c chain) Verify(genesis Genesis, from Digest, fac crypto.VerifierFactory) 
 		// Skip the verification until we reach the provided Digest. We still
 		// have to update the roster though.
 		if !toProcess && link.GetFrom() != from {
+			prev = link.GetTo()
 			authority = authority.Apply(link.GetChangeSet())
 			continue
 		}
@@ -383,6 +384,10 @@ func (c chain) Verify(genesis Genesis, from Digest, fac crypto.VerifierFactory) 
 		prev = link.GetTo()
 
 		authority = authority.Apply(link.GetChangeSet())
+	}
+
+	if !toProcess {
+		return xerrors.Errorf("no verification made (from Digest %v)", from)
 	}
 
 	return nil

--- a/core/ordering/cosipbft/types/chain_test.go
+++ b/core/ordering/cosipbft/types/chain_test.go
@@ -205,43 +205,44 @@ func TestChain_Verify(t *testing.T) {
 
 	c := NewChain(makeLink(t, genesis.digest), nil)
 
-	err = c.Verify(genesis, fake.VerifierFactory{})
+	err = c.Verify(genesis, genesis.GetHash(), fake.VerifierFactory{})
 	require.NoError(t, err)
 
-	err = c.Verify(genesis, fake.VerifierFactory{})
+	err = c.Verify(genesis, genesis.GetHash(), fake.VerifierFactory{})
 	require.NoError(t, err)
 
-	c = NewChain(makeLink(t, Digest{}), nil)
-	err = c.Verify(genesis, fake.VerifierFactory{})
+	l := makeLink(t, Digest{})
+	c = NewChain(l, nil)
+	err = c.Verify(genesis, l.GetFrom(), fake.VerifierFactory{})
 	require.EqualError(t, err, fmt.Sprintf("mismatch from: '00000000' != '%v'", genesis.GetHash()))
 
 	c = NewChain(makeLink(t, genesis.digest), nil)
-	err = c.Verify(genesis, fake.NewBadVerifierFactory())
+	err = c.Verify(genesis, genesis.GetHash(), fake.NewBadVerifierFactory())
 	require.EqualError(t, err, fake.Err("verifier factory failed"))
 
-	err = c.Verify(genesis, fake.NewVerifierFactory(fake.NewBadVerifier()))
+	err = c.Verify(genesis, genesis.GetHash(), fake.NewVerifierFactory(fake.NewBadVerifier()))
 	require.EqualError(t, err, fake.Err("invalid prepare signature"))
 
 	link := makeLink(t, genesis.digest).(blockLink)
 	link.prepareSig = nil
 	c = NewChain(link, nil)
-	err = c.Verify(genesis, fake.VerifierFactory{})
+	err = c.Verify(genesis, genesis.GetHash(), fake.VerifierFactory{})
 	require.EqualError(t, err, "unexpected nil prepare signature in link")
 
 	link.prepareSig = fake.Signature{}
 	link.commitSig = nil
 	c = NewChain(link, nil)
-	err = c.Verify(genesis, fake.VerifierFactory{})
+	err = c.Verify(genesis, genesis.GetHash(), fake.VerifierFactory{})
 	require.EqualError(t, err, "unexpected nil commit signature in link")
 
 	link.prepareSig = fake.NewBadSignature()
 	link.commitSig = fake.Signature{}
 	c = NewChain(link, nil)
-	err = c.Verify(genesis, fake.VerifierFactory{})
+	err = c.Verify(genesis, genesis.GetHash(), fake.VerifierFactory{})
 	require.EqualError(t, err, fake.Err("failed to marshal signature"))
 
 	c = NewChain(makeLink(t, genesis.digest), nil)
-	err = c.Verify(genesis, fake.NewVerifierFactory(fake.NewBadVerifierWithDelay(1)))
+	err = c.Verify(genesis, genesis.GetHash(), fake.NewVerifierFactory(fake.NewBadVerifierWithDelay(1)))
 	require.EqualError(t, err, fake.Err("invalid commit signature"))
 }
 

--- a/core/ordering/cosipbft/types/mod.go
+++ b/core/ordering/cosipbft/types/mod.go
@@ -4,7 +4,6 @@
 // when importing the serde formats.
 //
 // Documentation Last Review: 13.10.2020
-//
 package types
 
 import (
@@ -75,8 +74,8 @@ type Chain interface {
 	GetBlock() Block
 
 	// Verify takes the genesis block and the verifier factory that should
-	// verify the chain.
-	Verify(genesis Genesis, fac crypto.VerifierFactory) error
+	// verify the chain. Performs the verification starting at the link Digest.
+	Verify(genesis Genesis, from Digest, fac crypto.VerifierFactory) error
 }
 
 // ChainFactory is the interface to serialize and deserialize chains.

--- a/test/cosidela_test.go
+++ b/test/cosidela_test.go
@@ -10,7 +10,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -67,7 +66,7 @@ type cosiDela interface {
 //
 // - implements dela
 type cosiDelaNode struct {
-	t             *testing.T
+	t             require.TestingT
 	onet          mino.Mino
 	ordering      ordering.Service
 	cosi          *threshold.Threshold
@@ -78,7 +77,7 @@ type cosiDelaNode struct {
 	tree          hashtree.Tree
 }
 
-func newDelaNode(t *testing.T, path string, port int) dela {
+func newDelaNode(t require.TestingT, path string, port int) dela {
 	err := os.MkdirAll(path, 0700)
 	require.NoError(t, err)
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 
@@ -17,6 +18,7 @@ import (
 	"go.dedis.ch/dela/core/txn/signed"
 	"go.dedis.ch/dela/crypto/bls"
 	"go.dedis.ch/dela/crypto/loader"
+	"golang.org/x/xerrors"
 )
 
 func init() {
@@ -27,93 +29,99 @@ func init() {
 // Use the value contract
 // Check the state
 func TestIntegration_Value_Simple(t *testing.T) {
-	dir, err := os.MkdirTemp(os.TempDir(), "dela-integration-test")
-	require.NoError(t, err)
+	t.Run("3 nodes", getTest[*testing.T](3, 2))
+}
 
-	t.Logf("using temps dir %s", dir)
+func BenchmarkValue(b *testing.B) {
+	getTest[*testing.B](5, b.N)(b)
+}
 
-	defer os.RemoveAll(dir)
+func getTest[T require.TestingT](numNode, numTx int) func(t T) {
+	return func(t T) {
+		dir, err := os.MkdirTemp(os.TempDir(), "dela-integration-test")
+		require.NoError(t, err)
 
-	nodes := []dela{
-		newDelaNode(t, filepath.Join(dir, "node1"), 0),
-		newDelaNode(t, filepath.Join(dir, "node2"), 0),
-		newDelaNode(t, filepath.Join(dir, "node3"), 0),
+		defer os.RemoveAll(dir)
+
+		nodes := make([]dela, numNode)
+
+		for i := range nodes {
+			node := newDelaNode(t, filepath.Join(dir, "node"+strconv.Itoa(i)), 0)
+			nodes[i] = node
+		}
+
+		nodes[0].Setup(nodes[1:]...)
+
+		l := loader.NewFileLoader(filepath.Join(dir, "private.key"))
+
+		signerdata, err := l.LoadOrCreate(newKeyGenerator())
+		require.NoError(t, err)
+
+		signer, err := bls.NewSignerFromBytes(signerdata)
+		require.NoError(t, err)
+
+		pubKey := signer.GetPublicKey()
+		cred := accessContract.NewCreds(aKey[:])
+
+		for _, node := range nodes {
+			node.GetAccessService().Grant(node.(cosiDelaNode).GetAccessStore(), cred, pubKey)
+		}
+
+		manager := signed.NewManager(signer, &txClient{})
+
+		pubKeyBuf, err := signer.GetPublicKey().MarshalBinary()
+		require.NoError(t, err)
+
+		args := []txn.Arg{
+			{Key: "go.dedis.ch/dela.ContractArg", Value: []byte("go.dedis.ch/dela.Access")},
+			{Key: "access:grant_id", Value: []byte(hex.EncodeToString(valueAccessKey[:]))},
+			{Key: "access:grant_contract", Value: []byte("go.dedis.ch/dela.Value")},
+			{Key: "access:grant_command", Value: []byte("all")},
+			{Key: "access:identity", Value: []byte(base64.StdEncoding.EncodeToString(pubKeyBuf))},
+			{Key: "access:command", Value: []byte("GRANT")},
+		}
+
+		addAndWait(t, manager, nodes[0].(cosiDelaNode), args...)
+		require.NoError(t, err)
+
+		for i := 0; i < numTx; i++ {
+			key := make([]byte, 32)
+
+			_, err = rand.Read(key)
+			require.NoError(t, err)
+
+			args = []txn.Arg{
+				{Key: "go.dedis.ch/dela.ContractArg", Value: []byte("go.dedis.ch/dela.Value")},
+				{Key: "value:key", Value: key},
+				{Key: "value:value", Value: []byte("value1")},
+				{Key: "value:command", Value: []byte("WRITE")},
+			}
+
+			addAndWait(t, manager, nodes[0].(cosiDelaNode), args...)
+			require.NoError(t, err)
+
+			proof, err := nodes[0].GetOrdering().GetProof(key)
+			require.NoError(t, err)
+			require.Equal(t, []byte("value1"), proof.GetValue())
+		}
 	}
-
-	nodes[0].Setup(nodes[1:]...)
-
-	l := loader.NewFileLoader(filepath.Join(dir, "private.key"))
-
-	signerdata, err := l.LoadOrCreate(newKeyGenerator())
-	require.NoError(t, err)
-
-	signer, err := bls.NewSignerFromBytes(signerdata)
-	require.NoError(t, err)
-
-	pubKey := signer.GetPublicKey()
-	cred := accessContract.NewCreds(aKey[:])
-
-	for _, node := range nodes {
-		node.GetAccessService().Grant(node.(cosiDelaNode).GetAccessStore(), cred, pubKey)
-	}
-
-	manager := signed.NewManager(signer, &txClient{})
-
-	pubKeyBuf, err := signer.GetPublicKey().MarshalBinary()
-	require.NoError(t, err)
-
-	args := []txn.Arg{
-		{Key: "go.dedis.ch/dela.ContractArg", Value: []byte("go.dedis.ch/dela.Access")},
-		{Key: "access:grant_id", Value: []byte(hex.EncodeToString(valueAccessKey[:]))},
-		{Key: "access:grant_contract", Value: []byte("go.dedis.ch/dela.Value")},
-		{Key: "access:grant_command", Value: []byte("all")},
-		{Key: "access:identity", Value: []byte(base64.StdEncoding.EncodeToString(pubKeyBuf))},
-		{Key: "access:command", Value: []byte("GRANT")},
-	}
-	addAndWait(t, manager, nodes[0].(cosiDelaNode), args...)
-
-	key1 := make([]byte, 32)
-
-	_, err = rand.Read(key1)
-	require.NoError(t, err)
-
-	args = []txn.Arg{
-		{Key: "go.dedis.ch/dela.ContractArg", Value: []byte("go.dedis.ch/dela.Value")},
-		{Key: "value:key", Value: key1},
-		{Key: "value:value", Value: []byte("value1")},
-		{Key: "value:command", Value: []byte("WRITE")},
-	}
-	addAndWait(t, manager, nodes[0].(cosiDelaNode), args...)
-
-	proof, err := nodes[0].GetOrdering().GetProof(key1)
-	require.NoError(t, err)
-	require.Equal(t, []byte("value1"), proof.GetValue())
-
-	key2 := make([]byte, 32)
-
-	_, err = rand.Read(key2)
-	require.NoError(t, err)
-
-	args = []txn.Arg{
-		{Key: "go.dedis.ch/dela.ContractArg", Value: []byte("go.dedis.ch/dela.Value")},
-		{Key: "value:key", Value: key2},
-		{Key: "value:value", Value: []byte("value2")},
-		{Key: "value:command", Value: []byte("WRITE")},
-	}
-	addAndWait(t, manager, nodes[0].(cosiDelaNode), args...)
 }
 
 // -----------------------------------------------------------------------------
 // Utility functions
 
-func addAndWait(t *testing.T, manager txn.Manager, node cosiDelaNode, args ...txn.Arg) {
+func addAndWait(t require.TestingT, manager txn.Manager, node cosiDelaNode, args ...txn.Arg) error {
 	manager.Sync()
 
 	tx, err := manager.Make(args...)
-	require.NoError(t, err)
+	if err != nil {
+		return xerrors.Errorf("failed to make tx: %v", err)
+	}
 
 	err = node.GetPool().Add(tx)
-	require.NoError(t, err)
+	if err != nil {
+		return xerrors.Errorf("failed to add tx: %v", err)
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
 	defer cancel()
@@ -129,10 +137,10 @@ func addAndWait(t *testing.T, manager txn.Manager, node cosiDelaNode, args ...tx
 				require.Empty(t, err)
 
 				require.True(t, accepted)
-				return
+				return nil
 			}
 		}
 	}
 
-	t.Error("transaction not found")
+	return xerrors.New("transaction not included")
 }


### PR DESCRIPTION
- The chain verification verifies only from a given Digest, in case we trust blocks already stored
- GetProof will get links up to the last one, instead of blocklinks, sparing blocks unmarshalling and verification

Fix https://github.com/dedis/dela/issues/238