### PR TITLE
dkg start: honor `threshold` parameter

### DIFF
--- a/dkg/pedersen/dkg.go
+++ b/dkg/pedersen/dkg.go
@@ -8,7 +8,6 @@ import (
 	"github.com/dedis/debugtools/channel"
 	"github.com/rs/zerolog"
 	"go.dedis.ch/dela"
-	"go.dedis.ch/dela/cosi/threshold"
 	"go.dedis.ch/dela/dkg/pedersen/types"
 	"go.dedis.ch/dela/mino"
 	"go.dedis.ch/dela/serde"
@@ -200,7 +199,7 @@ func (s *instance) start(ctx context.Context, start types.Start, deals channel.T
 	}
 
 	// create the DKG
-	t := threshold.ByzantineThreshold(len(start.GetPublicKeys()))
+	t := start.GetThreshold()
 	d, err := pedersen.NewDistKeyGenerator(suite, s.privKey, start.GetPublicKeys(), t)
 	if err != nil {
 		return xerrors.Errorf("failed to create new DKG: %v", err)


### PR DESCRIPTION
The unintended behavior was introduced in ddb238b305d6cc05c7a92d7d5c049904488a65a3. After discussion on Slack, we concluded that this was a mistake and the correct behavior was to align with what the rest of the code thinks the threshold is.