### PR TITLE
Added prefix for value contract storage

### DIFF
--- a/contracts/value/value.go
+++ b/contracts/value/value.go
@@ -46,7 +46,7 @@ const (
 	credentialAllCommand = "all"
 
 	// contractKeyPrefix is used to prefix keys in the K/V store.
-	contractKeyPrefix = "VAL"
+	contractKeyPrefix = "VALU" // intentionally 4 bytes only, not a typo!
 )
 
 // Command defines a type of command for the value contract

--- a/contracts/value/value_test.go
+++ b/contracts/value/value_test.go
@@ -76,7 +76,7 @@ func TestCommand_Write(t *testing.T) {
 	_, found = contract.index["dummy"]
 	require.True(t, found)
 
-	res, err := snap.Get([]byte("dummy"))
+	res, err := snap.Get(prefix([]byte("dummy")))
 	require.NoError(t, err)
 	require.Equal(t, "value", string(res))
 }
@@ -98,7 +98,7 @@ func TestCommand_Read(t *testing.T) {
 	require.EqualError(t, err, fake.Err("failed to get key 'dummy'"))
 
 	snap := fake.NewSnapshot()
-	snap.Set(key, []byte("value"))
+	snap.Set(prefix(key), []byte("value"))
 
 	buf := &bytes.Buffer{}
 	cmd.Contract.printer = buf
@@ -127,13 +127,13 @@ func TestCommand_Delete(t *testing.T) {
 	require.EqualError(t, err, fake.Err("failed to delete key '"+keyHex+"'"))
 
 	snap := fake.NewSnapshot()
-	snap.Set(key, []byte("value"))
+	snap.Set(prefix(key), []byte("value"))
 	contract.index[keyStr] = struct{}{}
 
 	err = cmd.delete(snap, makeStep(t, KeyArg, keyStr))
 	require.NoError(t, err)
 
-	res, err := snap.Get(key)
+	res, err := snap.Get(prefix(key))
 	require.Nil(t, err)
 	require.Nil(t, res)
 
@@ -158,8 +158,8 @@ func TestCommand_List(t *testing.T) {
 	}
 
 	snap := fake.NewSnapshot()
-	snap.Set([]byte(key1), []byte("value1"))
-	snap.Set([]byte(key2), []byte("value2"))
+	snap.Set(prefix([]byte(key1)), []byte("value1"))
+	snap.Set(prefix([]byte(key2)), []byte("value2"))
 
 	err := cmd.list(snap)
 	require.NoError(t, err)

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -87,7 +87,7 @@ func getTest[T require.TestingT](numNode, numTx int) func(t T) {
 		require.NoError(t, err)
 
 		for i := 0; i < numTx; i++ {
-			key := make([]byte, 32)
+			key := make([]byte, 28) // only 224 bits are available
 
 			_, err = rand.Read(key)
 			require.NoError(t, err)
@@ -102,7 +102,7 @@ func getTest[T require.TestingT](numNode, numTx int) func(t T) {
 			err = addAndWait(t, timeout, manager, nodes[0].(cosiDelaNode), args...)
 			require.NoError(t, err)
 
-			proof, err := nodes[0].GetOrdering().GetProof(key)
+			proof, err := nodes[0].GetOrdering().GetProof(append([]byte("VALU"), key...))
 			require.NoError(t, err)
 			require.Equal(t, []byte("value1"), proof.GetValue())
 		}
@@ -112,7 +112,13 @@ func getTest[T require.TestingT](numNode, numTx int) func(t T) {
 // -----------------------------------------------------------------------------
 // Utility functions
 
-func addAndWait(t require.TestingT, to time.Duration, manager txn.Manager, node cosiDelaNode, args ...txn.Arg) error {
+func addAndWait(
+	t require.TestingT,
+	to time.Duration,
+	manager txn.Manager,
+	node cosiDelaNode,
+	args ...txn.Arg,
+) error {
 	manager.Sync()
 
 	tx, err := manager.Make(args...)


### PR DESCRIPTION
There's a weakness in Dela (#258) whereby the (existing) smart contracts store key=values without any prefix for the keys in a shared key/value store. Effectively this would allow any malicious user to overwrite other smart contracts' data.

This fixes it for the `value` contract.

We probably need to do something similar for https://github.com/dedis/d-voting

@PascalinDe @lanterno for your information, the current key/value store is limited to keys of 32 bytes. Do reach out if adding a prefix could be a problem for D-Voting (we haven't checked).
