### PR TITLE
Added prefix for DARC storage

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,52 +1,1 @@
-[*]
-charset = utf-8
-end_of_line = crlf
-indent_size = 4
-indent_style = space
-insert_final_newline = false
-max_line_length = 100
-tab_width = 4
-ij_continuation_indent_size = 4
-ij_formatter_off_tag = @formatter:off
-ij_formatter_on_tag = @formatter:on
-ij_formatter_tags_enabled = true
-ij_smart_tabs = false
-ij_visual_guides = 80
-ij_wrap_on_typing = false
-
-[.editorconfig]
-ij_editorconfig_align_group_field_declarations = false
-ij_editorconfig_space_after_colon = false
-ij_editorconfig_space_after_comma = true
-ij_editorconfig_space_before_colon = false
-ij_editorconfig_space_before_comma = false
-ij_editorconfig_spaces_around_assignment_operators = true
-
-[*.go]
-indent_style = tab
-ij_smart_tabs = true
-ij_go_GROUP_CURRENT_PROJECT_IMPORTS = true
-ij_go_add_leading_space_to_comments = true
-ij_go_add_parentheses_for_single_import = false
-ij_go_call_parameters_new_line_after_left_paren = false
-ij_go_call_parameters_right_paren_on_new_line = false
-ij_go_call_parameters_wrap = normal
-ij_go_fill_paragraph_width = 80
-ij_go_group_stdlib_imports = false
-ij_go_import_sorting = goimports
-ij_go_keep_indents_on_empty_lines = false
-ij_go_local_group_mode = project
-ij_go_move_all_imports_in_one_declaration = true
-ij_go_move_all_stdlib_imports_in_one_group = false
-ij_go_remove_redundant_import_aliases = true
-ij_go_run_go_fmt_on_reformat = true
-ij_go_use_back_quotes_for_imports = false
-ij_go_wrap_comp_lit = on_every_item
-ij_go_wrap_comp_lit_newline_after_lbrace = true
-ij_go_wrap_comp_lit_newline_before_rbrace = true
-ij_go_wrap_func_params = on_every_item
-ij_go_wrap_func_params_newline_after_lparen = true
-ij_go_wrap_func_params_newline_before_rparen = true
-ij_go_wrap_func_result = on_every_item
-ij_go_wrap_func_result_newline_after_lparen = true
-ij_go_wrap_func_result_newline_before_rparen = true
+[*]charset = utf-8end_of_line = lfindent_size = 4indent_style = spaceinsert_final_newline = falsemax_line_length = 100tab_width = 4ij_continuation_indent_size = 4ij_formatter_off_tag = @formatter:offij_formatter_on_tag = @formatter:onij_formatter_tags_enabled = trueij_smart_tabs = falseij_visual_guides = 80ij_wrap_on_typing = false[.editorconfig]ij_editorconfig_align_group_field_declarations = falseij_editorconfig_space_after_colon = falseij_editorconfig_space_after_comma = trueij_editorconfig_space_before_colon = falseij_editorconfig_space_before_comma = falseij_editorconfig_spaces_around_assignment_operators = true[*.go]indent_style = tabij_smart_tabs = trueij_go_GROUP_CURRENT_PROJECT_IMPORTS = trueij_go_add_leading_space_to_comments = trueij_go_add_parentheses_for_single_import = falseij_go_call_parameters_new_line_after_left_paren = falseij_go_call_parameters_right_paren_on_new_line = falseij_go_call_parameters_wrap = normalij_go_fill_paragraph_width = 80ij_go_group_stdlib_imports = falseij_go_import_sorting = goimportsij_go_keep_indents_on_empty_lines = falseij_go_local_group_mode = projectij_go_move_all_imports_in_one_declaration = trueij_go_move_all_stdlib_imports_in_one_group = falseij_go_remove_redundant_import_aliases = trueij_go_run_go_fmt_on_reformat = trueij_go_use_back_quotes_for_imports = falseij_go_wrap_comp_lit = on_every_itemij_go_wrap_comp_lit_newline_after_lbrace = trueij_go_wrap_comp_lit_newline_before_rbrace = trueij_go_wrap_func_params = on_every_itemij_go_wrap_func_params_newline_after_lparen = trueij_go_wrap_func_params_newline_before_rparen = trueij_go_wrap_func_result = on_every_itemij_go_wrap_func_result_newline_after_lparen = trueij_go_wrap_func_result_newline_before_rparen = true

--- a/contracts/access/access_test.go
+++ b/contracts/access/access_test.go
@@ -16,12 +16,12 @@ import (
 )
 
 func TestExecute(t *testing.T) {
-	contract := NewContract([]byte{}, fakeAccess{err: fake.GetError()}, fakeStore{})
+	contract := NewContract(fakeAccess{err: fake.GetError()}, fakeStore{})
 	err := contract.Execute(fakeStore{}, makeStep(t, CmdArg, ""))
 	require.EqualError(t, err,
 		"identity not authorized: fake.PublicKey ("+fake.GetError().Error()+")")
 
-	contract = NewContract([]byte{}, fakeAccess{}, fakeStore{})
+	contract = NewContract(fakeAccess{}, fakeStore{})
 	err = contract.Execute(fakeStore{}, makeStep(t, CmdArg, ""))
 	require.EqualError(t, err, "'access:command' not found in tx arg")
 
@@ -44,7 +44,7 @@ func TestExecute(t *testing.T) {
 }
 
 func TestGrant(t *testing.T) {
-	contract := NewContract([]byte{}, fakeAccess{}, fakeStore{})
+	contract := NewContract(fakeAccess{}, fakeStore{})
 	err := contract.grant(fakeStore{}, makeStep(t))
 	require.EqualError(t, err, "'access:grant_id' not found in tx arg")
 
@@ -86,7 +86,7 @@ func TestGrant(t *testing.T) {
 		IdentityArg, id))
 	require.NoError(t, err)
 
-	contract = NewContract([]byte{}, fakeAccess{err: fake.GetError()}, fakeStore{})
+	contract = NewContract(fakeAccess{err: fake.GetError()}, fakeStore{})
 	err = contract.grant(fakeStore{}, makeStep(t, GrantIDArg, "deadbeef",
 		GrantContractArg, "fake contract",
 		GrantCommandArg, "fake command",

--- a/contracts/access/controller/action.go
+++ b/contracts/access/controller/action.go
@@ -49,7 +49,7 @@ func (a addAction) Execute(ctx node.Context) error {
 		return xerrors.Errorf("failed to parse identities: %v", err)
 	}
 
-	err = asrv.Grant(accessStore, accessContract.NewCreds(aKey[:]), identities...)
+	err = asrv.Grant(accessStore, accessContract.NewCreds(), identities...)
 	if err != nil {
 		return xerrors.Errorf("failed to grant: %v", err)
 	}

--- a/contracts/access/controller/controller.go
+++ b/contracts/access/controller/controller.go
@@ -14,8 +14,6 @@ import (
 	"golang.org/x/xerrors"
 )
 
-var aKey = [28]byte{1}
-
 // newStore is the function used to create the new store. It allows us to create
 // a different store in the tests.
 var newStore = func(path string) (accessStore, error) {
@@ -68,7 +66,7 @@ func (m miniController) OnStart(flags cli.Flags, inj node.Injector) error {
 		return xerrors.Errorf("failed to create access store: %v", err)
 	}
 
-	contract := accessContract.NewContract(aKey[:], access, accessStore)
+	contract := accessContract.NewContract(access, accessStore)
 	accessContract.RegisterContract(exec, contract)
 
 	inj.Inject(accessStore)

--- a/contracts/access/controller/controller.go
+++ b/contracts/access/controller/controller.go
@@ -14,7 +14,7 @@ import (
 	"golang.org/x/xerrors"
 )
 
-var aKey = [32]byte{1}
+var aKey = [28]byte{1}
 
 // newStore is the function used to create the new store. It allows us to create
 // a different store in the tests.

--- a/contracts/value/controller/controller.go
+++ b/contracts/value/controller/controller.go
@@ -10,7 +10,7 @@ import (
 )
 
 // aKey is the access key used for the value contract
-var aKey = [32]byte{2}
+var aKey = [28]byte{2}
 
 // miniController is a CLI initializer to register the value contract
 //

--- a/contracts/value/controller/controller.go
+++ b/contracts/value/controller/controller.go
@@ -9,9 +9,6 @@ import (
 	"golang.org/x/xerrors"
 )
 
-// aKey is the access key used for the value contract
-var aKey = [28]byte{2}
-
 // miniController is a CLI initializer to register the value contract
 //
 // - implements node.Initializer
@@ -41,7 +38,7 @@ func (m miniController) OnStart(flags cli.Flags, inj node.Injector) error {
 		return xerrors.Errorf("failed to resolve native service: %v", err)
 	}
 
-	contract := value.NewContract(aKey[:], access)
+	contract := value.NewContract(access)
 
 	value.RegisterContract(exec, contract)
 

--- a/contracts/value/value.go
+++ b/contracts/value/value.go
@@ -46,7 +46,7 @@ const (
 	credentialAllCommand = "all"
 
 	// contractKeyPrefix is used to prefix keys in the K/V store.
-	contractKeyPrefix = "VAL"
+	contractKeyPrefix = "VALU" // intentionally 4 bytes only, not a typo!
 )
 
 // Command defines a type of command for the value contract

--- a/contracts/value/value_test.go
+++ b/contracts/value/value_test.go
@@ -17,13 +17,13 @@ import (
 )
 
 func TestExecute(t *testing.T) {
-	contract := NewContract([]byte{}, fakeAccess{err: fake.GetError()})
+	contract := NewContract(fakeAccess{err: fake.GetError()})
 
 	err := contract.Execute(fakeStore{}, makeStep(t))
 	require.EqualError(t, err,
 		"identity not authorized: fake.PublicKey ("+fake.GetError().Error()+")")
 
-	contract = NewContract([]byte{}, fakeAccess{})
+	contract = NewContract(fakeAccess{})
 	err = contract.Execute(fakeStore{}, makeStep(t))
 	require.EqualError(t, err, "'value:command' not found in tx arg")
 
@@ -50,7 +50,7 @@ func TestExecute(t *testing.T) {
 }
 
 func TestCommand_Write(t *testing.T) {
-	contract := NewContract([]byte{}, fakeAccess{})
+	contract := NewContract(fakeAccess{})
 
 	cmd := valueCommand{
 		Contract: &contract,
@@ -82,7 +82,7 @@ func TestCommand_Write(t *testing.T) {
 }
 
 func TestCommand_Read(t *testing.T) {
-	contract := NewContract([]byte{}, fakeAccess{})
+	contract := NewContract(fakeAccess{})
 
 	cmd := valueCommand{
 		Contract: &contract,
@@ -110,7 +110,7 @@ func TestCommand_Read(t *testing.T) {
 }
 
 func TestCommand_Delete(t *testing.T) {
-	contract := NewContract([]byte{}, fakeAccess{})
+	contract := NewContract(fakeAccess{})
 
 	cmd := valueCommand{
 		Contract: &contract,
@@ -142,7 +142,7 @@ func TestCommand_Delete(t *testing.T) {
 }
 
 func TestCommand_List(t *testing.T) {
-	contract := NewContract([]byte{}, fakeAccess{})
+	contract := NewContract(fakeAccess{})
 
 	key1 := "key1"
 	key2 := "key2"

--- a/contracts/value/value_test.go
+++ b/contracts/value/value_test.go
@@ -76,7 +76,7 @@ func TestCommand_Write(t *testing.T) {
 	_, found = contract.index["dummy"]
 	require.True(t, found)
 
-	res, err := snap.Get([]byte("dummy"))
+	res, err := snap.Get(prefix([]byte("dummy")))
 	require.NoError(t, err)
 	require.Equal(t, "value", string(res))
 }
@@ -98,7 +98,7 @@ func TestCommand_Read(t *testing.T) {
 	require.EqualError(t, err, fake.Err("failed to get key 'dummy'"))
 
 	snap := fake.NewSnapshot()
-	snap.Set(key, []byte("value"))
+	snap.Set(prefix(key), []byte("value"))
 
 	buf := &bytes.Buffer{}
 	cmd.Contract.printer = buf
@@ -127,13 +127,13 @@ func TestCommand_Delete(t *testing.T) {
 	require.EqualError(t, err, fake.Err("failed to delete key '"+keyHex+"'"))
 
 	snap := fake.NewSnapshot()
-	snap.Set(key, []byte("value"))
+	snap.Set(prefix(key), []byte("value"))
 	contract.index[keyStr] = struct{}{}
 
 	err = cmd.delete(snap, makeStep(t, KeyArg, keyStr))
 	require.NoError(t, err)
 
-	res, err := snap.Get(key)
+	res, err := snap.Get(prefix(key))
 	require.Nil(t, err)
 	require.Nil(t, res)
 
@@ -158,8 +158,8 @@ func TestCommand_List(t *testing.T) {
 	}
 
 	snap := fake.NewSnapshot()
-	snap.Set([]byte(key1), []byte("value1"))
-	snap.Set([]byte(key2), []byte("value2"))
+	snap.Set(prefix([]byte(key1)), []byte("value1"))
+	snap.Set(prefix([]byte(key2)), []byte("value2"))
 
 	err := cmd.list(snap)
 	require.NoError(t, err)

--- a/contracts/value/value_test.go
+++ b/contracts/value/value_test.go
@@ -11,6 +11,7 @@ import (
 	"go.dedis.ch/dela/core/execution"
 	"go.dedis.ch/dela/core/execution/native"
 	"go.dedis.ch/dela/core/store"
+	"go.dedis.ch/dela/core/store/prefixed"
 	"go.dedis.ch/dela/core/txn"
 	"go.dedis.ch/dela/core/txn/signed"
 	"go.dedis.ch/dela/testing/fake"
@@ -56,27 +57,29 @@ func TestCommand_Write(t *testing.T) {
 		Contract: &contract,
 	}
 
-	err := cmd.write(fake.NewSnapshot(), makeStep(t))
+	snap := prefixed.NewSnapshot(ContractUID, fake.NewSnapshot())
+	err := cmd.write(snap, makeStep(t))
 	require.EqualError(t, err, "'value:key' not found in tx arg")
 
-	err = cmd.write(fake.NewSnapshot(), makeStep(t, KeyArg, "dummy"))
+	snap = prefixed.NewSnapshot(ContractUID, fake.NewSnapshot())
+	err = cmd.write(snap, makeStep(t, KeyArg, "dummy"))
 	require.EqualError(t, err, "'value:value' not found in tx arg")
 
-	err = cmd.write(fake.NewBadSnapshot(), makeStep(t, KeyArg, "dummy", ValueArg, "value"))
+	snap = prefixed.NewSnapshot(ContractUID, fake.NewBadSnapshot())
+	err = cmd.write(snap, makeStep(t, KeyArg, "dummy", ValueArg, "value"))
 	require.EqualError(t, err, fake.Err("failed to set value"))
-
-	snap := fake.NewSnapshot()
 
 	_, found := contract.index["dummy"]
 	require.False(t, found)
 
+	snap = prefixed.NewSnapshot(ContractUID, fake.NewSnapshot())
 	err = cmd.write(snap, makeStep(t, KeyArg, "dummy", ValueArg, "value"))
 	require.NoError(t, err)
 
 	_, found = contract.index["dummy"]
 	require.True(t, found)
 
-	res, err := snap.Get(prefix([]byte("dummy")))
+	res, err := snap.Get([]byte("dummy"))
 	require.NoError(t, err)
 	require.Equal(t, "value", string(res))
 }
@@ -91,14 +94,17 @@ func TestCommand_Read(t *testing.T) {
 	key := []byte("dummy")
 	keyHex := hex.EncodeToString(key)
 
-	err := cmd.read(fake.NewSnapshot(), makeStep(t))
+	snap := prefixed.NewSnapshot(ContractUID, fake.NewSnapshot())
+	err := cmd.read(snap, makeStep(t))
 	require.EqualError(t, err, "'value:key' not found in tx arg")
 
-	err = cmd.read(fake.NewBadSnapshot(), makeStep(t, KeyArg, "dummy"))
+	badSnap := prefixed.NewSnapshot(ContractUID, fake.NewBadSnapshot())
+	err = cmd.read(badSnap, makeStep(t, KeyArg, "dummy"))
 	require.EqualError(t, err, fake.Err("failed to get key 'dummy'"))
 
-	snap := fake.NewSnapshot()
-	snap.Set(prefix(key), []byte("value"))
+	snap = prefixed.NewSnapshot(ContractUID, fake.NewSnapshot())
+	err = snap.Set(key, []byte("value"))
+	require.NoError(t, err)
 
 	buf := &bytes.Buffer{}
 	cmd.Contract.printer = buf
@@ -120,20 +126,23 @@ func TestCommand_Delete(t *testing.T) {
 	keyHex := hex.EncodeToString(key)
 	keyStr := string(key)
 
-	err := cmd.delete(fake.NewSnapshot(), makeStep(t))
+	snap := prefixed.NewSnapshot(ContractUID, fake.NewSnapshot())
+	err := cmd.delete(snap, makeStep(t))
 	require.EqualError(t, err, "'value:key' not found in tx arg")
 
-	err = cmd.delete(fake.NewBadSnapshot(), makeStep(t, KeyArg, keyStr))
+	badSnap := prefixed.NewSnapshot(ContractUID, fake.NewBadSnapshot())
+	err = cmd.delete(badSnap, makeStep(t, KeyArg, keyStr))
 	require.EqualError(t, err, fake.Err("failed to delete key '"+keyHex+"'"))
 
-	snap := fake.NewSnapshot()
-	snap.Set(prefix(key), []byte("value"))
+	snap = prefixed.NewSnapshot(ContractUID, fake.NewSnapshot())
+	err = snap.Set(key, []byte("value"))
+	require.NoError(t, err)
 	contract.index[keyStr] = struct{}{}
 
 	err = cmd.delete(snap, makeStep(t, KeyArg, keyStr))
 	require.NoError(t, err)
 
-	res, err := snap.Get(prefix(key))
+	res, err := snap.Get(key)
 	require.Nil(t, err)
 	require.Nil(t, res)
 
@@ -157,16 +166,19 @@ func TestCommand_List(t *testing.T) {
 		Contract: &contract,
 	}
 
-	snap := fake.NewSnapshot()
-	snap.Set(prefix([]byte(key1)), []byte("value1"))
-	snap.Set(prefix([]byte(key2)), []byte("value2"))
+	snap := prefixed.NewSnapshot(ContractUID, fake.NewSnapshot())
+	err := snap.Set([]byte(key1), []byte("value1"))
+	require.NoError(t, err)
+	err = snap.Set([]byte(key2), []byte("value2"))
+	require.NoError(t, err)
 
-	err := cmd.list(snap)
+	err = cmd.list(snap)
 	require.NoError(t, err)
 
 	require.Equal(t, fmt.Sprintf("%x=value1,%x=value2", key1, key2), buf.String())
 
-	err = cmd.list(fake.NewBadSnapshot())
+	badSnap := prefixed.NewSnapshot(ContractUID, fake.NewBadSnapshot())
+	err = cmd.list(badSnap)
 	// we can't assume an order from the map
 	require.Regexp(t, "^failed to get key", err.Error())
 }
@@ -220,11 +232,11 @@ type fakeStore struct {
 	store.Snapshot
 }
 
-func (s fakeStore) Get(key []byte) ([]byte, error) {
+func (s fakeStore) Get(_ []byte) ([]byte, error) {
 	return nil, nil
 }
 
-func (s fakeStore) Set(key, value []byte) error {
+func (s fakeStore) Set(_, _ []byte) error {
 	return nil
 }
 
@@ -232,18 +244,18 @@ type fakeCmd struct {
 	err error
 }
 
-func (c fakeCmd) write(snap store.Snapshot, step execution.Step) error {
+func (c fakeCmd) write(_ store.Snapshot, _ execution.Step) error {
 	return c.err
 }
 
-func (c fakeCmd) read(snap store.Snapshot, step execution.Step) error {
+func (c fakeCmd) read(_ store.Snapshot, _ execution.Step) error {
 	return c.err
 }
 
-func (c fakeCmd) delete(snap store.Snapshot, step execution.Step) error {
+func (c fakeCmd) delete(_ store.Snapshot, _ execution.Step) error {
 	return c.err
 }
 
-func (c fakeCmd) list(snap store.Snapshot) error {
+func (c fakeCmd) list(_ store.Snapshot) error {
 	return c.err
 }

--- a/core/access/darc/darc.go
+++ b/core/access/darc/darc.go
@@ -76,7 +76,7 @@ func (srvc Service) Grant(
 		return xerrors.Errorf("failed to serialize: %v", err)
 	}
 
-	err = store.Set(cred.GetID(), value)
+	err = store.Set(prefixKey(cred.GetID()), value)
 	if err != nil {
 		return xerrors.Errorf("store failed to write: %v", err)
 	}
@@ -85,7 +85,7 @@ func (srvc Service) Grant(
 }
 
 func (srvc Service) readPermission(store store.Readable, key []byte) (types.Permission, error) {
-	value, err := store.Get(key)
+	value, err := store.Get(prefixKey(key))
 	if err != nil {
 		return nil, xerrors.Errorf("while reading: %v", err)
 	}
@@ -100,4 +100,11 @@ func (srvc Service) readPermission(store store.Readable, key []byte) (types.Perm
 	}
 
 	return perm, nil
+}
+
+// 4 bytes used to prefix DARC keys in the K/V store.
+const darcPrefix = "DARC"
+
+func prefixKey(key []byte) []byte {
+	return append([]byte(darcPrefix), key...)
 }

--- a/core/access/darc/darc.go
+++ b/core/access/darc/darc.go
@@ -31,7 +31,11 @@ func NewService(ctx serde.Context) Service {
 // Match implements access.Service. It returns nil if the group of identities
 // have access to the given credentials, otherwise a meaningful error on the
 // reason if it does not have access.
-func (srvc Service) Match(store store.Readable, creds access.Credential, idents ...access.Identity) error {
+func (srvc Service) Match(
+	store store.Readable,
+	creds access.Credential,
+	idents ...access.Identity,
+) error {
 	perm, err := srvc.readPermission(store, creds.GetID())
 	if err != nil {
 		return xerrors.Errorf("store failed: %v", err)
@@ -51,7 +55,11 @@ func (srvc Service) Match(store store.Readable, creds access.Credential, idents 
 
 // Grant implements access.Service. It updates or creates the credential and
 // grants the access to the group of identities.
-func (srvc Service) Grant(store store.Snapshot, cred access.Credential, idents ...access.Identity) error {
+func (srvc Service) Grant(
+	store store.Snapshot,
+	cred access.Credential,
+	idents ...access.Identity,
+) error {
 	perm, err := srvc.readPermission(store, cred.GetID())
 	if err != nil {
 		return xerrors.Errorf("store failed: %v", err)

--- a/core/access/darc/darc.go
+++ b/core/access/darc/darc.go
@@ -11,6 +11,9 @@ import (
 	"golang.org/x/xerrors"
 )
 
+// 4 bytes used to prefix DARC keys in the K/V store.
+const ContractUID = "DARC"
+
 // Service is an implementation of an access service that will allow one to
 // store and verify access for a group of identities.
 //
@@ -76,7 +79,7 @@ func (srvc Service) Grant(
 		return xerrors.Errorf("failed to serialize: %v", err)
 	}
 
-	err = store.Set(prefixKey(cred.GetID()), value)
+	err = store.Set(cred.GetID(), value)
 	if err != nil {
 		return xerrors.Errorf("store failed to write: %v", err)
 	}
@@ -85,7 +88,7 @@ func (srvc Service) Grant(
 }
 
 func (srvc Service) readPermission(store store.Readable, key []byte) (types.Permission, error) {
-	value, err := store.Get(prefixKey(key))
+	value, err := store.Get(key)
 	if err != nil {
 		return nil, xerrors.Errorf("while reading: %v", err)
 	}
@@ -100,11 +103,4 @@ func (srvc Service) readPermission(store store.Readable, key []byte) (types.Perm
 	}
 
 	return perm, nil
-}
-
-// 4 bytes used to prefix DARC keys in the K/V store.
-const darcPrefix = "DARC"
-
-func prefixKey(key []byte) []byte {
-	return append([]byte(darcPrefix), key...)
 }

--- a/core/access/darc/darc_test.go
+++ b/core/access/darc/darc_test.go
@@ -27,8 +27,8 @@ func TestService_Match(t *testing.T) {
 	data, err := perm.Serialize(testCtx)
 	require.NoError(t, err)
 
-	store.Set([]byte{0xaa}, data)
-	store.Set([]byte{0xbb}, []byte{})
+	store.Set(append([]byte("DARC"), 0xaa), data)
+	store.Set(append([]byte("DARC"), 0xbb), []byte{})
 
 	srvc := NewService(testCtx)
 
@@ -57,7 +57,7 @@ func TestService_Match(t *testing.T) {
 
 func TestService_Grant(t *testing.T) {
 	store := fake.NewSnapshot()
-	store.Set([]byte{0xbb}, []byte{})
+	store.Set(append([]byte("DARC"), 0xbb), []byte{})
 
 	creds := access.NewContractCreds([]byte{0xaa}, "test", "grant")
 

--- a/core/execution/native/example_test.go
+++ b/core/execution/native/example_test.go
@@ -90,6 +90,10 @@ func (exampleContract) Execute(store store.Snapshot, step execution.Step) error 
 	return nil
 }
 
+func (exampleContract) UID() string {
+	return "EXPL"
+}
+
 // inMemoryStore in a simple implementation of a store using an in-memory
 // map.
 //

--- a/core/execution/native/native.go
+++ b/core/execution/native/native.go
@@ -45,7 +45,8 @@ func NewExecution() *Service {
 // this contract by using the same name as the contract argument.
 func (ns *Service) Set(name string, contract Contract) {
 	// Check if the contract is already registered
-	if _, ok := ns.contracts[name]; ok {
+	_, found := ns.contracts[name]
+	if found {
 		panic(xerrors.Errorf("contract '%s' already registered", name))
 	}
 
@@ -57,7 +58,8 @@ func (ns *Service) Set(name string, contract Contract) {
 	}
 
 	// Check if the contract's UID is already registered
-	if _, ok := ns.contractUIDs[uid]; ok {
+	_, found = ns.contractUIDs[uid]
+	if found {
 		panic(xerrors.Errorf("contract UID '%x' for '%s' already registered", uid, name))
 	}
 

--- a/core/ordering/cosipbft/contracts/viewchange/viewchange_test.go
+++ b/core/ordering/cosipbft/contracts/viewchange/viewchange_test.go
@@ -40,7 +40,7 @@ func TestNewTransaction(t *testing.T) {
 func TestContract_Execute(t *testing.T) {
 	fac := authority.NewFactory(fake.AddressFactory{}, fake.PublicKeyFactory{})
 
-	contract := NewContract([]byte("roster"), []byte("access"), fac, fakeAccess{})
+	contract := NewContract(fac, fakeAccess{})
 
 	err := contract.Execute(fakeStore{}, makeStep(t, "[]"))
 	require.NoError(t, err)

--- a/core/ordering/cosipbft/controller/controller.go
+++ b/core/ordering/cosipbft/controller/controller.go
@@ -38,7 +38,7 @@ import (
 const privateKeyFile = "private.key"
 
 // valueAccessKey is the access key used for the value contract.
-var valueAccessKey = [32]byte{2}
+var valueAccessKey = [28]byte{2}
 
 func blsSigner() encoding.BinaryMarshaler {
 	return bls.NewSigner()

--- a/core/ordering/cosipbft/controller/controller.go
+++ b/core/ordering/cosipbft/controller/controller.go
@@ -37,9 +37,6 @@ import (
 
 const privateKeyFile = "private.key"
 
-// valueAccessKey is the access key used for the value contract.
-var valueAccessKey = [28]byte{2}
-
 func blsSigner() encoding.BinaryMarshaler {
 	return bls.NewSigner()
 }

--- a/core/ordering/cosipbft/controller/controller.go
+++ b/core/ordering/cosipbft/controller/controller.go
@@ -178,7 +178,8 @@ func (m miniController) OnStart(flags cli.Flags, inj node.Injector) error {
 		return xerrors.Errorf("failed to load blocks: %v", err)
 	}
 
-	srvc, err := cosipbft.NewService(param, cosipbft.WithGenesisStore(genstore), cosipbft.WithBlockStore(blocks))
+	srvc, err := cosipbft.NewService(param, cosipbft.WithGenesisStore(genstore),
+		cosipbft.WithBlockStore(blocks))
 	if err != nil {
 		return xerrors.Errorf("service: %v", err)
 	}

--- a/core/ordering/cosipbft/controller/controller.go
+++ b/core/ordering/cosipbft/controller/controller.go
@@ -127,7 +127,7 @@ func (m miniController) OnStart(flags cli.Flags, inj node.Injector) error {
 	rosterFac := authority.NewFactory(onet.GetAddressFactory(), cosi.GetPublicKeyFactory())
 	cosipbft.RegisterRosterContract(exec, rosterFac, access)
 
-	value.RegisterContract(exec, value.NewContract(valueAccessKey[:], access))
+	value.RegisterContract(exec, value.NewContract(access))
 
 	txFac := signed.NewTransactionFactory()
 	vs := simple.NewService(exec, txFac)

--- a/core/ordering/cosipbft/cosipbft.go
+++ b/core/ordering/cosipbft/cosipbft.go
@@ -86,7 +86,7 @@ const (
 // RegisterRosterContract registers the native smart contract to update the
 // roster to the given service.
 func RegisterRosterContract(exec *native.Service, rFac authority.Factory, srvc access.Service) {
-	contract := viewchange.NewContract(keyRoster[:], keyAccess[:], rFac, srvc)
+	contract := viewchange.NewContract(rFac, srvc)
 
 	viewchange.RegisterContract(exec, contract)
 }

--- a/core/ordering/cosipbft/cosipbft_test.go
+++ b/core/ordering/cosipbft/cosipbft_test.go
@@ -64,25 +64,25 @@ func TestService_Scenario_Basic(t *testing.T) {
 	err = nodes[0].pool.Add(makeTx(t, 0, signer))
 	require.NoError(t, err)
 
-	evt := waitEvent(t, events, 2*DefaultRoundTimeout)
+	evt := waitEvent(t, events, 3*DefaultRoundTimeout)
 	require.Equal(t, uint64(0), evt.Index)
 
 	err = nodes[1].pool.Add(makeTx(t, 1, signer))
 	require.NoError(t, err)
 
-	evt = waitEvent(t, events, 20*DefaultRoundTimeout)
+	evt = waitEvent(t, events, 10*DefaultRoundTimeout)
 	require.Equal(t, uint64(1), evt.Index)
 
 	err = nodes[1].pool.Add(makeRosterTx(t, 2, ro, signer))
 	require.NoError(t, err)
 
-	evt = waitEvent(t, events, 20*DefaultRoundTimeout)
+	evt = waitEvent(t, events, 10*DefaultRoundTimeout)
 	require.Equal(t, uint64(2), evt.Index)
 	for i := 0; i < 3; i++ {
 		err = nodes[1].pool.Add(makeTx(t, uint64(i+3), signer))
 		require.NoError(t, err)
 
-		evt = waitEvent(t, events, 20*DefaultRoundTimeout)
+		evt = waitEvent(t, events, 10*DefaultRoundTimeout)
 		require.Equal(t, uint64(i+3), evt.Index)
 	}
 

--- a/core/ordering/cosipbft/cosipbft_test.go
+++ b/core/ordering/cosipbft/cosipbft_test.go
@@ -43,6 +43,8 @@ import (
 	"go.dedis.ch/dela/testing/fake"
 )
 
+// This test is known to be VERY flaky on Windows.
+// Further investigation is needed.
 func TestService_Scenario_Basic(t *testing.T) {
 	nodes, ro, clean := makeAuthority(t, 5)
 	defer clean()
@@ -84,11 +86,11 @@ func TestService_Scenario_Basic(t *testing.T) {
 		require.Equal(t, uint64(i+3), evt.Index)
 	}
 
-	proof, err := nodes[0].service.GetProof(keyRoster[:])
+	proof, err := nodes[0].service.GetProof(viewchange.GetRosterKey())
 	require.NoError(t, err)
 	require.NotNil(t, proof.GetValue())
 
-	require.Equal(t, keyRoster[:], proof.GetKey())
+	require.Equal(t, viewchange.GetRosterKey(), proof.GetKey())
 	require.NotNil(t, proof.GetValue())
 
 	checkProof(t, proof.(Proof), nodes[0].service)
@@ -933,6 +935,10 @@ type testExec struct {
 
 func (e testExec) Execute(store.Snapshot, execution.Step) error {
 	return e.err
+}
+
+func (e testExec) UID() string {
+	return "TEST"
 }
 
 func makeTx(t *testing.T, nonce uint64, signer crypto.Signer) txn.Transaction {

--- a/core/ordering/cosipbft/proc.go
+++ b/core/ordering/cosipbft/proc.go
@@ -29,8 +29,8 @@ import (
 )
 
 var (
-	keyRoster = [32]byte{}
-	keyAccess = [32]byte{1}
+	keyRoster = [28]byte{}
+	keyAccess = [28]byte{1}
 )
 
 // Processor processes the messages to run a collective signing PBFT consensus.

--- a/core/ordering/cosipbft/proc.go
+++ b/core/ordering/cosipbft/proc.go
@@ -28,11 +28,6 @@ import (
 	"golang.org/x/xerrors"
 )
 
-var (
-	keyRoster = [28]byte{}
-	keyAccess = [28]byte{1}
-)
-
 // Processor processes the messages to run a collective signing PBFT consensus.
 //
 // - implements cosi.Reactor
@@ -176,7 +171,7 @@ func (h *processor) getCurrentRoster() (authority.Authority, error) {
 }
 
 func (h *processor) readRoster(tree hashtree.Tree) (authority.Authority, error) {
-	data, err := tree.Get(keyRoster[:])
+	data, err := tree.Get(viewchange.GetRosterKey())
 	if err != nil {
 		return nil, xerrors.Errorf("read from tree: %v", err)
 	}
@@ -201,7 +196,7 @@ func (h *processor) storeGenesis(roster authority.Authority, match *types.Digest
 			return xerrors.Errorf("failed to set access: %v", err)
 		}
 
-		err = snap.Set(keyRoster[:], value)
+		err = snap.Set(viewchange.GetRosterKey(), value)
 		if err != nil {
 			return xerrors.Errorf("failed to store roster: %v", err)
 		}
@@ -242,7 +237,7 @@ func (h *processor) storeGenesis(roster authority.Authority, match *types.Digest
 }
 
 func (h *processor) makeAccess(store store.Snapshot, roster authority.Authority) error {
-	creds := viewchange.NewCreds(keyAccess[:])
+	creds := viewchange.NewCreds()
 
 	iter := roster.PublicKeyIterator()
 	for iter.HasNext() {

--- a/core/ordering/pow/pow_test.go
+++ b/core/ordering/pow/pow_test.go
@@ -169,6 +169,10 @@ func (e testExec) Execute(store store.Snapshot, step execution.Step) error {
 	return nil
 }
 
+func (e testExec) UID() string {
+	return "TEST"
+}
+
 type badValidation struct {
 	validation.Service
 }

--- a/core/store/prefixed/prefixed.go
+++ b/core/store/prefixed/prefixed.go
@@ -1,0 +1,74 @@
+package prefixed
+
+import (
+	"encoding/binary"
+
+	"go.dedis.ch/dela/core/store"
+	"go.dedis.ch/dela/crypto"
+)
+
+type readable struct {
+	store.Readable
+	prefix []byte
+}
+
+type writable struct {
+	store.Writable
+	prefix []byte
+}
+
+type snapshot struct {
+	*writable
+	*readable
+}
+
+// NewSnapShot creates a new prefixed Snapshot.
+func NewSnapshot(prefix string, snap store.Snapshot) store.Snapshot {
+	p := []byte(prefix)
+	return &snapshot{
+		&writable{snap, p},
+		&readable{snap, p},
+	}
+}
+
+// Get implements store.Readable
+// It takes a key as input and returns a value or error status
+func (s *readable) Get(key []byte) ([]byte, error) {
+
+	k := NewPrefixedKey(s.prefix, key)
+	return s.Readable.Get(k)
+}
+
+// Set implements store.Writable
+// It takes a key and value as input, and returns an error status
+func (s *writable) Set(key []byte, value []byte) error {
+	k := NewPrefixedKey(s.prefix, key)
+	return s.Writable.Set(k, value)
+}
+
+// Delete implements store.Writable
+// It takes a key as input and returns an error status
+func (s *writable) Delete(key []byte) error {
+	k := NewPrefixedKey(s.prefix, key)
+	return s.Writable.Delete(k)
+}
+
+// NewPrefixedKey is exported because it is used in integration tests.
+// It creates a 256bit (hashed) key from a prefix and a base key.
+func NewPrefixedKey(prefix, key []byte) []byte {
+	h := crypto.NewHashFactory(crypto.Sha256).New()
+
+	length := []byte{0, 0}
+	binary.LittleEndian.PutUint16(length, uint16(len(prefix)))
+
+	h.Write(length)
+	h.Write(prefix)
+
+	length = []byte{0, 0}
+	binary.LittleEndian.PutUint16(length, uint16(len(key)))
+
+	h.Write(length)
+	h.Write(key)
+
+	return h.Sum(nil)
+}

--- a/core/validation/simple/example_test.go
+++ b/core/validation/simple/example_test.go
@@ -86,6 +86,10 @@ func (exampleContract) Execute(store.Snapshot, execution.Step) error {
 	return nil
 }
 
+func (exampleContract) UID() string {
+	return "EXPL"
+}
+
 // inMemoryStore in a simple implementation of a store using an in-memory
 // map.
 //

--- a/test/cosidela_test.go
+++ b/test/cosidela_test.go
@@ -49,9 +49,6 @@ import (
 const certKeyName = "cert.key"
 const privateKeyFile = "private.key"
 
-var aKey = [28]byte{1}
-var valueAccessKey = [28]byte{2}
-
 // cosiDela defines the interface needed to use a Dela node using cosi.
 type cosiDela interface {
 	dela
@@ -127,7 +124,7 @@ func newDelaNode(t require.TestingT, path string, port int) dela {
 	rosterFac := authority.NewFactory(onet.GetAddressFactory(), cosi.GetPublicKeyFactory())
 	cosipbft.RegisterRosterContract(exec, rosterFac, accessService)
 
-	value.RegisterContract(exec, value.NewContract(valueAccessKey[:], accessService))
+	value.RegisterContract(exec, value.NewContract(accessService))
 
 	txFac := signed.NewTransactionFactory()
 	vs := simple.NewService(exec, txFac)
@@ -175,7 +172,7 @@ func newDelaNode(t require.TestingT, path string, port int) dela {
 
 	// access
 	accessStore := newAccessStore()
-	contract := accessContract.NewContract(aKey[:], accessService, accessStore)
+	contract := accessContract.NewContract(accessService, accessStore)
 	accessContract.RegisterContract(exec, contract)
 
 	return cosiDelaNode{

--- a/test/cosidela_test.go
+++ b/test/cosidela_test.go
@@ -49,8 +49,8 @@ import (
 const certKeyName = "cert.key"
 const privateKeyFile = "private.key"
 
-var aKey = [32]byte{1}
-var valueAccessKey = [32]byte{2}
+var aKey = [28]byte{1}
+var valueAccessKey = [28]byte{2}
 
 // cosiDela defines the interface needed to use a Dela node using cosi.
 type cosiDela interface {

--- a/test/cosidela_test.go
+++ b/test/cosidela_test.go
@@ -93,7 +93,8 @@ func newDelaNode(t require.TestingT, path string, port int) dela {
 
 	fload := loader.NewFileLoader(filepath.Join(path, certKeyName))
 
-	keydata, err := fload.LoadOrCreate(newCertGenerator(rand.New(rand.NewSource(0)), elliptic.P521()))
+	keydata, err := fload.LoadOrCreate(newCertGenerator(rand.New(rand.NewSource(0)),
+		elliptic.P521()))
 	require.NoError(t, err)
 
 	key, err := x509.ParseECPrivateKey(keydata)

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	accessContract "go.dedis.ch/dela/contracts/access"
+	"go.dedis.ch/dela/contracts/value"
 	"go.dedis.ch/dela/core/txn"
 	"go.dedis.ch/dela/core/txn/signed"
 	"go.dedis.ch/dela/crypto/bls"
@@ -63,7 +64,7 @@ func getTest[T require.TestingT](numNode, numTx int) func(t T) {
 		require.NoError(t, err)
 
 		pubKey := signer.GetPublicKey()
-		cred := accessContract.NewCreds(aKey[:])
+		cred := accessContract.NewCreds()
 
 		for _, node := range nodes {
 			node.GetAccessService().Grant(node.(cosiDelaNode).GetAccessStore(), cred, pubKey)
@@ -76,7 +77,7 @@ func getTest[T require.TestingT](numNode, numTx int) func(t T) {
 
 		args := []txn.Arg{
 			{Key: "go.dedis.ch/dela.ContractArg", Value: []byte("go.dedis.ch/dela.Access")},
-			{Key: "access:grant_id", Value: []byte(hex.EncodeToString(valueAccessKey[:]))},
+			{Key: "access:grant_id", Value: []byte(hex.EncodeToString([]byte(value.ContractUID)))},
 			{Key: "access:grant_contract", Value: []byte("go.dedis.ch/dela.Value")},
 			{Key: "access:grant_command", Value: []byte("all")},
 			{Key: "access:identity", Value: []byte(base64.StdEncoding.EncodeToString(pubKeyBuf))},

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -87,7 +87,7 @@ func getTest[T require.TestingT](numNode, numTx int) func(t T) {
 		require.NoError(t, err)
 
 		for i := 0; i < numTx; i++ {
-			key := make([]byte, 32)
+			key := make([]byte, 28) // only 224 bits are available
 
 			_, err = rand.Read(key)
 			require.NoError(t, err)
@@ -102,7 +102,7 @@ func getTest[T require.TestingT](numNode, numTx int) func(t T) {
 			err = addAndWait(t, timeout, manager, nodes[0].(cosiDelaNode), args...)
 			require.NoError(t, err)
 
-			proof, err := nodes[0].GetOrdering().GetProof(key)
+			proof, err := nodes[0].GetOrdering().GetProof(append([]byte("VALU"), key...))
 			require.NoError(t, err)
 			require.Equal(t, []byte("value1"), proof.GetValue())
 		}
@@ -112,7 +112,13 @@ func getTest[T require.TestingT](numNode, numTx int) func(t T) {
 // -----------------------------------------------------------------------------
 // Utility functions
 
-func addAndWait(t require.TestingT, to time.Duration, manager txn.Manager, node cosiDelaNode, args ...txn.Arg) error {
+func addAndWait(
+	t require.TestingT,
+	to time.Duration,
+	manager txn.Manager,
+	node cosiDelaNode,
+	args ...txn.Arg,
+) error {
 	manager.Sync()
 
 	tx, err := manager.Make(args...)

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -89,7 +89,7 @@ func getTest[T require.TestingT](numNode, numTx int) func(t T) {
 		require.NoError(t, err)
 
 		for i := 0; i < numTx; i++ {
-			key := make([]byte, 32) // only 224 bits are available
+			key := make([]byte, 32)
 
 			_, err = rand.Read(key)
 			require.NoError(t, err)
@@ -104,7 +104,7 @@ func getTest[T require.TestingT](numNode, numTx int) func(t T) {
 			err = addAndWait(t, timeout, manager, nodes[0].(cosiDelaNode), args...)
 			require.NoError(t, err)
 
-			prefixedKey := prefixed.NewPrefixedKey([]byte("VALU"), key)
+			prefixedKey := prefixed.NewPrefixedKey([]byte(value.ContractUID), key)
 			proof, err := nodes[0].GetOrdering().GetProof(prefixedKey)
 			require.NoError(t, err)
 			require.Equal(t, []byte("value1"), proof.GetValue())

--- a/testing/fake/store.go
+++ b/testing/fake/store.go
@@ -139,8 +139,8 @@ func (tx dbTx) GetBucketOrCreate(name []byte) (kv.Bucket, error) {
 	return bucket, tx.err
 }
 
-// GetBucketOrCreate implements store.Transaction.
-func (dbTx) OnCommit(fn func()) {}
+// OnCommit implements store.Transaction.
+func (dbTx) OnCommit(_ func()) {}
 
 // Bucket is a fake key/value storage bucket.
 //


### PR DESCRIPTION
There's a weakness in Dela (https://github.com/dedis/dela/issues/258) whereby the (existing) smart contracts store key=values without any prefix for the keys in a shared key/value store. Effectively this would allow any malicious user to overwrite other smart contracts' data.

This fixes it for the Distributed Access Rights Controls (DARC) functionality.