### PR TITLE
More realistic fake.InMemorySnapshot

### DIFF
--- a/contracts/value/value_test.go
+++ b/contracts/value/value_test.go
@@ -144,7 +144,7 @@ func TestCommand_Delete(t *testing.T) {
 
 	res, err := snap.Get(key)
 	require.Nil(t, err)
-	require.Nil(t, res)
+	require.Nil(t, res) // = "key not found"
 
 	_, found := contract.index[keyStr]
 	require.False(t, found)

--- a/core/access/darc/darc.go
+++ b/core/access/darc/darc.go
@@ -4,15 +4,14 @@
 package darc
 
 import (
+	contract "go.dedis.ch/dela/contracts/access"
 	"go.dedis.ch/dela/core/access"
 	"go.dedis.ch/dela/core/access/darc/types"
 	"go.dedis.ch/dela/core/store"
+	"go.dedis.ch/dela/core/store/prefixed"
 	"go.dedis.ch/dela/serde"
 	"golang.org/x/xerrors"
 )
-
-// 4 bytes used to prefix DARC keys in the K/V store.
-const ContractUID = "DARC"
 
 // Service is an implementation of an access service that will allow one to
 // store and verify access for a group of identities.
@@ -39,6 +38,7 @@ func (srvc Service) Match(
 	creds access.Credential,
 	idents ...access.Identity,
 ) error {
+	store = prefixed.NewReadable(contract.ContractUID, store)
 	perm, err := srvc.readPermission(store, creds.GetID())
 	if err != nil {
 		return xerrors.Errorf("store failed: %v", err)
@@ -63,6 +63,8 @@ func (srvc Service) Grant(
 	cred access.Credential,
 	idents ...access.Identity,
 ) error {
+	store = prefixed.NewSnapshot(contract.ContractUID, store)
+
 	perm, err := srvc.readPermission(store, cred.GetID())
 	if err != nil {
 		return xerrors.Errorf("store failed: %v", err)

--- a/core/store/prefixed/prefixed.go
+++ b/core/store/prefixed/prefixed.go
@@ -22,13 +22,19 @@ type snapshot struct {
 	*readable
 }
 
-// NewSnapShot creates a new prefixed Snapshot.
+// NewSnapshot creates a new prefixed Snapshot.
 func NewSnapshot(prefix string, snap store.Snapshot) store.Snapshot {
 	p := []byte(prefix)
 	return &snapshot{
 		&writable{snap, p},
 		&readable{snap, p},
 	}
+}
+
+// NewReadable creates a new prefixed Readable.
+func NewReadable(prefix string, r store.Readable) store.Readable {
+	p := []byte(prefix)
+	return &readable{r, p}
 }
 
 // Get implements store.Readable

--- a/core/store/store.go
+++ b/core/store/store.go
@@ -12,6 +12,9 @@ type Readable interface {
 type Writable interface {
 	Set(key []byte, value []byte) error
 
+	// Delete deletes a given key.
+	// It can return an error if deleting from a read-only store
+	// No error is returned if the key does not exist.
 	Delete(key []byte) error
 }
 

--- a/testing/fake/store.go
+++ b/testing/fake/store.go
@@ -65,12 +65,6 @@ func (snap *InMemorySnapshot) Delete(key []byte) error {
 		return snap.ErrDelete
 	}
 
-	_, found := snap.values[string(key)]
-	if !found {
-		// is this behaviour correct or should it be ignored ?
-		return xerrors.Errorf("key not found: %s", key)
-	}
-
 	delete(snap.values, string(key))
 
 	return nil

--- a/testing/fake/store.go
+++ b/testing/fake/store.go
@@ -3,7 +3,6 @@ package fake
 import (
 	"go.dedis.ch/dela/core/store"
 	"go.dedis.ch/dela/core/store/kv"
-	"golang.org/x/xerrors"
 )
 
 // InMemorySnapshot is a fake implementation of a store snapshot.
@@ -45,7 +44,7 @@ func (snap *InMemorySnapshot) Get(key []byte) ([]byte, error) {
 	if found {
 		return value, nil
 	}
-	return nil, xerrors.Errorf("key not found: %s", key)
+	return nil, nil
 }
 
 // Set implements store.Snapshot.


### PR DESCRIPTION
Some tests were becoming hard to write with the super-simple fake `InMemorySnapshot`.
This should make things easier, but carries the risk of breaking things.
This draft PR was created to let the CI scream at us while we proceed with other developments.