### PR TITLE
Draft: use BigEndian order for Bolt to maintain correct ordering (closes #269)

### DIFF
--- a/core/ordering/cosipbft/blockstore/disk.go
+++ b/core/ordering/cosipbft/blockstore/disk.go
@@ -306,7 +306,7 @@ func (s *InDisk) doView(fn func(tx kv.ReadableTx) error) error {
 
 func (s *InDisk) makeKey(index uint64) []byte {
 	key := make([]byte, 8)
-	binary.LittleEndian.PutUint64(key, index)
+	binary.BigEndian.PutUint64(key, index)
 
 	return key
 }


### PR DESCRIPTION
closes #269 